### PR TITLE
Added the cosets splitting of a group

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AtomicSymmetries"
 uuid = "7e24f7a5-8a44-4f91-9a93-7ee03df51e54"
 authors = ["Lorenzo Monacelli <mesonepigreco@gmail.com>"]
-version = "0.10.5"
+version = "0.11.0"
 
 [deps]
 Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"

--- a/src/AtomicSymmetries.jl
+++ b/src/AtomicSymmetries.jl
@@ -51,7 +51,8 @@ export get_symmetry_group_from_spglib,
        get_irreducible_q_indices,
        get_R_lat!, get_supercell, get_supercell!,
        get_reciprocal_lattice!, cryst_cart_conv!,
-       shift_position_origin!
+       shift_position_origin!,
+       CosetSymmetryGroup
 
 
 

--- a/src/filter_symmetries.jl
+++ b/src/filter_symmetries.jl
@@ -1,4 +1,42 @@
 @doc raw"""
+    CosetSymmetryGroup{T <: GenericSymmetries} <: GenericSymmetries
+
+This is a way to represent a symmetry group as a subgroup times its coset representatives.
+This is useful to apply symmetries to a perturbation that breaks the group.
+
+The full original group G is obtained by combining every coset representative ``g_k`` with the subgroup ``H``.
+Full symmetrization on ``G`` is equivalent to first symmetrize with respect to the cosets,
+then impose the symmetries of the subgroup ``H``. For this reason,
+the cosets are intended as right cosets, i.e. applying ``g_k`` to the element ``h_j`` of
+the representation of ``H`` is done to the right-side.
+
+```math
+h_j g_k
+```
+
+The subgroup ``H`` is the largest subgroup of ``G`` that leaves the perturbation vector invariant.
+The coset representatives ``g_k`` (including the identity) satisfy ``G = \bigcup_k H g_k``.
+
+The constructor can be called as
+
+```julia
+CosetSymmetryGroup(original_group :: Symmetries{T}, perturbation_vector :: AbstractVector, cell :: AbstractMatrix; buffer=default_buffer())
+CosetSymmetryGroup(original_group :: SymmetriesQSpace{T}, perturbation_vector :: AbstractVector, cell :: AbstractMatrix; buffer=default_buffer())
+```
+
+"""
+struct CosetSymmetryGroup{T <: GenericSymmetries} <: GenericSymmetries
+    subgroup :: T
+    cosets :: T
+end
+
+get_dimensions(csg :: CosetSymmetryGroup) = get_dimensions(csg.subgroup)
+get_n_atoms(csg :: CosetSymmetryGroup) = get_n_atoms(csg.subgroup)
+Base.length(csg :: CosetSymmetryGroup) = length(csg.subgroup) * length(csg.cosets)
+
+
+
+@doc raw"""
     symmetry_violation_mask!(mask :: Vector{Bool}, 
                           symmetry_group :: Symmetries,
                           vector :: AbstractVector,
@@ -87,16 +125,20 @@ function filter_invariant_symmetries!(symmetry_group :: Symmetries, vector :: Ab
         mask = @alloc(Bool, length(symmetry_group))
 
         symmetry_violation_mask!(mask, symmetry_group, vector, cell; buffer=buffer)
+        has_translations = length(symmetry_group.translations) == length(mask)
         # Delete from reverse to avoid bugs
         for i in length(mask):-1:1
             if mask[i]
                 deleteat!(symmetry_group.symmetries, i)
                 deleteat!(symmetry_group.irt, i)
                 deleteat!(symmetry_group.unit_cell_translations, i)
+                if has_translations
+                    deleteat!(symmetry_group.translations, i)
+                end
             end
         end
     end
-    
+
     # Update the symmetry group
     update_symmetry_functions!(symmetry_group)
 end
@@ -118,14 +160,17 @@ function filter_invariant_symmetries!(q_symmetry_group :: SymmetriesQSpace, vect
         mask = @alloc(Bool, length(q_symmetry_group))
 
         symmetry_violation_mask!(mask, q_symmetry_group.symmetries, vector, cell; buffer=buffer)
+        has_translations = length(q_symmetry_group.symmetries.translations) == length(mask)
         # Delete from reverse to avoid bugs
-        @show mask
         for i in length(mask):-1:1
             if mask[i]
                 deleteat!(q_symmetry_group.symmetries.symmetries, i)
                 deleteat!(q_symmetry_group.symmetries.irt, i)
                 deleteat!(q_symmetry_group.symmetries.unit_cell_translations, i)
                 deleteat!(q_symmetry_group.irt_q, i)
+                if has_translations
+                    deleteat!(q_symmetry_group.symmetries.translations, i)
+                end
             end
         end
     end
@@ -133,4 +178,103 @@ function filter_invariant_symmetries!(q_symmetry_group :: SymmetriesQSpace, vect
     # Update the symmetry group
     update_symmetry_functions!(q_symmetry_group.symmetries)
 end
+
+
+@doc raw"""
+    CosetSymmetryGroup(original_group :: Symmetries{T}, perturbation_vector :: AbstractVector, cell :: AbstractMatrix; buffer=default_buffer()) where T
+
+Construct a `CosetSymmetryGroup` by decomposing `original_group` into a subgroup invariant
+under `perturbation_vector` and its right coset representatives.
+
+The perturbation vector is assumed in Cartesian coordinates.
+"""
+function CosetSymmetryGroup(original_group :: Symmetries{T}, perturbation_vector :: AbstractVector, cell :: AbstractMatrix; buffer=default_buffer()) where T
+    n_symmetries_original = length(original_group)
+    n_dims = get_dimensions(original_group)
+    nat = get_n_atoms(original_group)
+
+    # Compute which symmetries are violated by the perturbation
+    mask_violation = Vector{Bool}(undef, n_symmetries_original)
+    symmetry_violation_mask!(mask_violation, original_group, perturbation_vector, cell; buffer=buffer)
+
+    # Build the subgroup: deepcopy and filter out violated symmetries
+    subgroup = deepcopy(original_group)
+    filter_invariant_symmetries!(subgroup, perturbation_vector, cell; buffer=buffer)
+    n_subgroup = length(subgroup)
+
+    # Track which elements of G are covered by existing cosets
+    covered = falses(n_symmetries_original)
+
+    # Mark subgroup elements as covered (they belong to the trivial coset H*e)
+    for i in 1:n_symmetries_original
+        if !mask_violation[i]
+            covered[i] = true
+        end
+    end
+
+    # Build the cosets Symmetries object, starting with identity
+    cosets_group = get_identity_symmetry_group(T; dims=n_dims, n_atoms=nat, translations=true)
+
+    # Find additional coset representatives
+    for i in 1:n_symmetries_original
+        if covered[i]
+            continue
+        end
+
+        # i is a new coset representative
+        g_i = original_group.symmetries[i]
+        g_i_inv = inv(g_i)
+
+        # Add to cosets group
+        add_symmetry!(cosets_group, g_i; update=false, irt=copy(original_group.irt[i]))
+        if length(original_group.translations) >= i
+            push!(cosets_group.translations, copy(original_group.translations[i]))
+        end
+        push!(cosets_group.unit_cell_translations, copy(original_group.unit_cell_translations[i]))
+
+        # Mark all elements in the right coset H * g_i as covered
+        for j in 1:n_symmetries_original
+            if covered[j]
+                continue
+            end
+            # Check if original_group[j] * g_i^{-1} ∈ H
+            product = original_group.symmetries[j] * g_i_inv
+            for k in 1:n_subgroup
+                if maximum(abs.(product .- subgroup.symmetries[k])) < 1e-6
+                    covered[j] = true
+                    break
+                end
+            end
+        end
+    end
+
+    @assert all(covered) "Not all elements of G were covered by cosets. This indicates a bug in the coset decomposition."
+    @assert length(cosets_group) * n_subgroup == n_symmetries_original "Coset decomposition inconsistent: $(length(cosets_group)) cosets × $(n_subgroup) subgroup ≠ $(n_symmetries_original) original"
+
+    update_symmetry_functions!(cosets_group)
+
+    return CosetSymmetryGroup{Symmetries{T}}(subgroup, cosets_group)
+end
+
+@doc raw"""
+    CosetSymmetryGroup(original_group :: SymmetriesQSpace{T}, perturbation_vector :: AbstractVector, cell :: AbstractMatrix; buffer=default_buffer()) where T
+
+Construct a `CosetSymmetryGroup` for a q-space symmetry group. The subgroup and cosets
+are wrapped as `SymmetriesQSpace` with properly initialized `irt_q`.
+"""
+function CosetSymmetryGroup(original_group :: SymmetriesQSpace{T}, perturbation_vector :: AbstractVector, cell :: AbstractMatrix; buffer=default_buffer()) where T
+    # Build the real-space coset decomposition
+    real_coset = CosetSymmetryGroup(original_group.symmetries, perturbation_vector, cell; buffer=buffer)
+
+    # Wrap both subgroup and cosets in SymmetriesQSpace to compute irt_q
+    q_points = original_group.q_points
+    subgroup_q = SymmetriesQSpace(real_coset.subgroup, q_points; buffer=buffer)
+    cosets_q = SymmetriesQSpace(real_coset.cosets, q_points; buffer=buffer)
+
+    return CosetSymmetryGroup{SymmetriesQSpace{T}}(subgroup_q, cosets_q)
+
+end
+
+
+
 

--- a/src/symmetrize_qspace.jl
+++ b/src/symmetrize_qspace.jl
@@ -48,6 +48,7 @@ function SymmetriesQSpace(symmetries :: Symmetries{T}, q_points :: AbstractMatri
     SymmetriesQSpace(symmetries, my_q_points, irt_q, minus_q_index)
 end
 
+get_dimensions(x ::SymmetriesQSpace) = get_dimensions(x.symmetries)
 Base.isempty(x :: SymmetriesQSpace) = isempty(x.symmetries)
 Base.length(x :: SymmetriesQSpace) = length(x.symmetries)
 function Base.getindex(x :: SymmetriesQSpace, k) 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,10 +28,16 @@ include("test_r3m.jl")
 end
 
 include("test_filter.jl")
-@testset "Filter" begin 
+@testset "Filter" begin
     test_filter()
     test_filter_full_vector()
     test_filter_fourier()
+end
+
+include("test_coset_decomposition.jl")
+@testset "Coset decomposition" begin
+    test_coset_decomposition()
+    test_coset_decomposition_qspace()
 end
 
 @testset "Cart to Crystal" begin

--- a/test/test_coset_decomposition.jl
+++ b/test/test_coset_decomposition.jl
@@ -1,0 +1,149 @@
+using AtomicSymmetries
+using LinearAlgebra
+using Test
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    include("define_cell.jl")
+end
+
+
+function test_coset_decomposition(; verbose=false)
+    positions, cell, types = get_pm3m_perovskite()
+    original_group = get_symmetry_group_from_spglib(positions, cell, types)
+
+    n_original = length(original_group)
+    if verbose
+        println("Number of original symmetries: ", n_original)
+    end
+
+    # Build CosetSymmetryGroup with [1,0,0] perturbation
+    perturbation = [1.0, 0.0, 0.0]
+    coset_group = CosetSymmetryGroup(original_group, perturbation, cell)
+
+    n_subgroup = length(coset_group.subgroup)
+    n_cosets = length(coset_group.cosets)
+
+    if verbose
+        println("Number of subgroup symmetries: ", n_subgroup)
+        println("Number of coset representatives: ", n_cosets)
+    end
+
+    # Test 1: |subgroup| * |cosets| == |original_group|
+    @test n_subgroup * n_cosets == n_original
+
+    # Test 2: The subgroup should have 8 symmetries (C4v for cubic with [1,0,0] perturbation)
+    @test n_subgroup == 8
+    @test n_cosets == 6  # 48/8
+
+    # Test 3: The subgroup is invariant under the perturbation
+    # (filtering it again should not remove any element)
+    subgroup_copy = deepcopy(coset_group.subgroup)
+    filter_invariant_symmetries!(subgroup_copy, perturbation, cell)
+    @test length(subgroup_copy) == n_subgroup
+
+    # Test 4: Each coset representative combined with the subgroup
+    # reconstructs elements of the original group (right cosets: h_j * g_k)
+    n_found = 0
+    for k in 1:n_cosets
+        g_k = coset_group.cosets.symmetries[k]
+        for j in 1:n_subgroup
+            h_j = coset_group.subgroup.symmetries[j]
+            composed = h_j * g_k
+
+            # Check this is in the original group
+            found = false
+            for i in 1:n_original
+                if maximum(abs.(composed .- original_group.symmetries[i])) < 1e-6
+                    found = true
+                    break
+                end
+            end
+            @test found
+            if found
+                n_found += 1
+            end
+        end
+    end
+    @test n_found == n_original
+
+    # Test 5: All cosets are disjoint (no element of G appears in two different cosets)
+    all_composed = Matrix{Float64}[]
+    for k in 1:n_cosets
+        g_k = coset_group.cosets.symmetries[k]
+        for j in 1:n_subgroup
+            h_j = coset_group.subgroup.symmetries[j]
+            push!(all_composed, h_j * g_k)
+        end
+    end
+    for i in 1:length(all_composed)
+        for j in i+1:length(all_composed)
+            @test maximum(abs.(all_composed[i] .- all_composed[j])) > 1e-6
+        end
+    end
+
+    # Test 6: irt is properly initialized for cosets
+    nat = original_group.n_particles
+    for k in 1:n_cosets
+        @test length(coset_group.cosets.irt[k]) == nat
+        # irt values should be valid atom indices
+        for idx in coset_group.cosets.irt[k]
+            @test 1 <= idx <= nat
+        end
+    end
+end
+
+
+function test_coset_decomposition_qspace(; verbose=false)
+    positions, cell, types = get_pm3m_perovskite()
+    original_group = get_symmetry_group_from_spglib(positions, cell, types)
+
+    # Create a q-point grid (2x2x2 for a cubic cell)
+    q_points = Float64[0 0.5 0 0 0.5 0.5 0 0.5;
+                       0 0 0.5 0 0.5 0 0.5 0.5;
+                       0 0 0 0.5 0 0.5 0.5 0.5]
+    q_group = SymmetriesQSpace(original_group, q_points)
+
+    n_original = length(q_group)
+    if verbose
+        println("Q-space: Number of original symmetries: ", n_original)
+    end
+
+    perturbation = [1.0, 0.0, 0.0]
+    coset_group = CosetSymmetryGroup(q_group, perturbation, cell)
+
+    n_subgroup = length(coset_group.subgroup)
+    n_cosets = length(coset_group.cosets)
+
+    if verbose
+        println("Q-space: Number of subgroup symmetries: ", n_subgroup)
+        println("Q-space: Number of coset representatives: ", n_cosets)
+    end
+
+    # Test 1: |subgroup| * |cosets| == |original_group|
+    @test n_subgroup * n_cosets == n_original
+
+    # Test 2: irt_q is properly initialized for both subgroup and cosets
+    nq = size(q_points, 2)
+    for k in 1:n_cosets
+        @test length(coset_group.cosets.irt_q[k]) == nq
+        for idx in coset_group.cosets.irt_q[k]
+            @test 1 <= idx <= nq
+        end
+    end
+    for k in 1:n_subgroup
+        @test length(coset_group.subgroup.irt_q[k]) == nq
+        for idx in coset_group.subgroup.irt_q[k]
+            @test 1 <= idx <= nq
+        end
+    end
+
+    # Test 3: The real-space part is consistent
+    @test length(coset_group.subgroup.symmetries) == n_subgroup
+    @test length(coset_group.cosets.symmetries) == n_cosets
+end
+
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    test_coset_decomposition(verbose=true)
+    test_coset_decomposition_qspace(verbose=true)
+end


### PR DESCRIPTION
This branch allows to split a group into the biggest subgroup that is invariant under a specific perturbation and a coset that maps the subgroup into the full group.
This is very useful to apply the complete group symmetries to perturbations that locally violate some symmetries (but whose final response functions satisfy all of them).