### PR TITLE
Adding support for dividing a spacegroup into subgroups + cosets

### DIFF
--- a/docs/src/fourier_symmetries.md
+++ b/docs/src/fourier_symmetries.md
@@ -146,8 +146,11 @@ S[\tilde\Phi_{ab}(\bm q)] = S^\dagger \tilde\Phi_{s(a)s(b)}(S_\text{recip}\bm q)
 
 Note that the ``S_\text{recip}q`` vector in the phase factor and in the dynamical matrix can be always folded back into the first Brilluin zone. In fact the dynamical matrix is periodic in the reciprocal vector, while the phase factor is multiplied by a direct lattice vector. Thus, by adding a reciprocal lattice vector ``\bm G`` to ``S_\text{recip}\bm q``, the phase factor is multiplied by ``e^{2\pi i \bm G\cdot ( \bm t_{s,a} - \bm t_{s,b})}``, which is always equal to 1.
 
+The application of symmetries is handled by the general function `rotate_vector!` and `rotate_dynamical_matrix!` or `rotate_matrix!` that works exactly like for real space symmetries, with the same general interface. However, we also provide specific q-space only functions. Note that, while the `rotate_*` functions works in cartesian space, the following one expects symmetries in real space.
+
 This transformation for each q point is operated by the subroutine `apply_symmetry_matrixq!`. Both these function modify in-place the first argument, storing the result of the transformation there. 
 Note that, since symmetries are stored in crystalline components, both the vector and the matrix must be in crystalline components. This makes it also important that the ``\bm q`` points are provided in crystalline coordinates, to correctly compute the phase factor and the transformed ``S\bm q``.
+
 
 ```@docs
 SymmetriesQSpace

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -50,6 +50,16 @@ symmetry_group.symmetrize_centroid!(vector)
 symmetry_group.symmetrize_fc!(matrix)
 ```
 
+### Apply the symmetry operations
+
+To apply a symmetry operation in general on a vector, we provide a general interface working both in real space and q-space. These subroutines works in cartesian coordinates:
+
+```@docs
+rotate_vector!
+rotate_matrix!
+rotate_dynamical_matrix!
+```
+
 ### Build your own symmetry group (API)
 
 To build a custom symmetry group, you can exploit the following subroutines

--- a/src/AtomicSymmetries.jl
+++ b/src/AtomicSymmetries.jl
@@ -19,6 +19,7 @@ include("filter_symmetries.jl")
 include("crystal.jl")
 include("sparsify.jl")
 include("fourier_transform.jl")
+include("apply_symmetry_general_interface.jl")
 
 export get_symmetry_group_from_spglib,
        get_nsymmetries,
@@ -47,6 +48,9 @@ export get_symmetry_group_from_spglib,
        symmetrize_vector_cartesian_q!,
        symmetrize_matrix_cartesian_q!,
        impose_hermitianity_q!,
+       rotate_vector!,
+       rotate_matrix!,
+       rotate_dynamical_matrix!,
        get_minus_q!,
        get_irreducible_q_indices,
        get_R_lat!, get_supercell, get_supercell!,

--- a/src/apply_symmetry_general_interface.jl
+++ b/src/apply_symmetry_general_interface.jl
@@ -1,0 +1,334 @@
+@doc raw"""
+    rotate_vector!(new_vector :: AbstractVector{T}, old_vector :: AbstractVector{T}, cell :: Matrix{T},
+            reciprocal_vectors :: Matrix{T},
+            symmetry_group :: Symmetries, sym_index :: Int; buffer=default_buffer())
+    rotate_vector!(new_vector :: AbstractMatrix{Complex{T}}, old_vector :: AbstractMatrix{Complex{T}},
+            cell :: Matrix{T}, reciprocal_vectors :: Matrix{T},
+            symmetry_group :: SymmetriesQSpace, sym_index :: Int; buffer=default_buffer())
+
+Apply a **single** symmetry operation on a vector (e.g. a displacement or force).
+The vector must be provided in Cartesian coordinates; the conversion to crystal
+coordinates and back is handled internally.
+
+This function works both with `SymmetriesQSpace` and with standard real-space
+`Symmetries`, thanks to multiple dispatch.
+
+**Real-space version** — the vector has length ``n_\text{dims} \times n_\text{atoms}``
+and the operation applies the symmetry rotation plus the atom permutation:
+
+```math
+\vec v'_{\text{irt}[a]} = S\, \vec v_{a}
+```
+
+**Q-space version** — the vector has size ``(n_\text{modes},\, n_q)`` and the
+operation additionally permutes q-points according to the symmetry:
+
+```math
+\vec v'_{\text{irt}[a]}(q') = S\, \vec v_{a}(q), \qquad q' = S^{-T} q
+```
+
+To symmetrize a vector (average over all symmetries), call this function for
+each symmetry and average the result. That is equivalent to what
+`symmetrize_vector!` (real space) or `symmetrize_vector_cartesian_q!` (q space)
+do internally.
+
+## Parameters
+
+- `new_vector` : Output rotated vector (modified in-place)
+- `old_vector` : Input vector to be rotated
+- `cell` : Primitive cell matrix (lattice vectors as columns)
+- `reciprocal_vectors` : Reciprocal lattice vectors (column-wise)
+- `symmetry_group` : The symmetry group (`Symmetries` or `SymmetriesQSpace`)
+- `sym_index` : Index of the symmetry operation to apply (``1 \le \text{sym\_index} \le N_\text{sym}``)
+- `buffer` : Optional Bumper.jl buffer for stack allocations
+
+## Example
+
+```julia
+n_sym = get_nsymmetries(sym_group)
+avg = zeros(length(vector))
+rotated = zeros(length(vector))
+for i in 1:n_sym
+    rotated .= 0
+    rotate_vector!(rotated, vector, cell, reciprocal_vectors, sym_group, i)
+    avg .+= rotated
+end
+avg ./= n_sym  # same as symmetrize_vector!(vector, cell, sym_group)
+```
+
+## See also
+
+- [`symmetrize_vector!`](@ref) — symmetrize a vector in real space (Cartesian)
+- [`symmetrize_vector_cartesian_q!`](@ref) — symmetrize a vector in q space (Cartesian)
+"""
+function rotate_vector!(new_vector :: AbstractVector{T}, old_vector :: AbstractVector{T}, cell :: Matrix{T},
+        reciprocal_vectors :: Matrix{T}, symmetry_group :: Symmetries, sym_index :: Int; buffer=default_buffer()) where T
+
+    # Get the dimensions
+    n_dims = get_dimensions(symmetry_group)
+    n_modes = length(new_vector)
+    n_atoms = n_modes ÷ n_dims
+    new_vector .= zero(T)
+
+    @no_escape buffer begin
+        tmp_vector = @alloc(T, n_modes)
+
+        # Convert to crystal
+        cryst_cart_conv!(reshape(tmp_vector, n_dims, :),
+                         reshape(old_vector, n_dims, :),
+                         cell, reciprocal_vectors, false; q_space=false)
+
+        # Apply the matrix
+        apply_sym_centroid!(new_vector, tmp_vector, symmetry_group.symmetries[sym_index], n_dims, symmetry_group.irt[sym_index]; buffer)
+        tmp_vector .= new_vector
+
+        # Convert back to cartesian
+        cryst_cart_conv!(reshape(new_vector, n_dims, :),
+                         reshape(tmp_vector, n_dims, :),
+                         cell, reciprocal_vectors, true; q_space=false)
+        nothing
+    end
+end
+function rotate_vector!(new_vector :: AbstractMatrix{Complex{T}}, old_vector :: AbstractMatrix{Complex{T}},
+        cell :: Matrix{T}, reciprocal_vectors :: Matrix{T},
+        symmetry_group :: SymmetriesQSpace, sym_index :: Int; buffer=default_buffer()) where T
+
+    # Get the dimensions
+    n_q = size(new_vector, 2)
+    n_dims = get_dimensions(symmetry_group)
+    n_modes = size(new_vector, 1)
+    n_atoms = n_modes ÷ n_dims
+    new_vector .= zero(Complex{T})
+
+    @no_escape buffer begin
+        tmp_vector = @alloc(Complex{T}, n_modes, n_q)
+
+        # Convert to crystal
+        cryst_cart_conv!(reshape(tmp_vector, n_dims, :),
+                         reshape(old_vector, n_dims, :),
+                         cell, reciprocal_vectors, false; q_space=false)
+
+        # Apply the matrix
+        apply_symmetry_vectorq!(new_vector, tmp_vector, symmetry_group[sym_index], symmetry_group.symmetries.irt[sym_index],
+                                symmetry_group.irt_q[sym_index])
+        tmp_vector .= new_vector
+
+        # Convert back to cartesian
+        cryst_cart_conv!(reshape(new_vector, n_dims, :),
+                         reshape(tmp_vector, n_dims, :),
+                         cell, reciprocal_vectors, true; q_space=false)
+        nothing
+    end
+end
+
+
+@doc raw"""
+    rotate_matrix!(new_matrix :: AbstractMatrix{T}, old_matrix :: AbstractMatrix{T}, cell :: Matrix{T},
+            reciprocal_vectors :: Matrix{T},
+            symmetry_group :: Symmetries, sym_index :: Int; buffer=default_buffer()) where T
+    rotate_matrix!(new_matrix :: AbstractMatrix{T}, old_matrix :: AbstractMatrix{T}, cell :: Matrix{T},
+            reciprocal_vectors :: Matrix{T},
+            symmetry_group :: SymmetriesQSpace, sym_index :: Int; buffer=default_buffer()) where T
+
+Apply a **single** symmetry operation on an intensive ``n_\text{dims} \times n_\text{dims}``
+matrix (e.g. a stress tensor or a dielectric tensor).
+The matrix must be provided in Cartesian coordinates; the conversion to crystal
+coordinates and back is handled internally.
+
+The operation performed is a second-rank tensor rotation:
+
+```math
+M' = S^\top\, M\, S
+```
+
+where ``S`` is the symmetry rotation matrix (in crystal coordinates).
+
+Since an intensive matrix is q-independent, both the `Symmetries` and
+`SymmetriesQSpace` dispatches perform exactly the same operation
+(the `SymmetriesQSpace` version delegates to the `Symmetries` version).
+
+To symmetrize a matrix, call this function for each symmetry and average. For
+a cubic crystal, the averaged stress tensor will be proportional to the
+identity matrix.
+
+## Parameters
+
+- `new_matrix` : Output rotated matrix (modified in-place)
+- `old_matrix` : Input matrix to be rotated
+- `cell` : Primitive cell matrix (lattice vectors as columns)
+- `reciprocal_vectors` : Reciprocal lattice vectors (column-wise)
+- `symmetry_group` : The symmetry group (`Symmetries` or `SymmetriesQSpace`)
+- `sym_index` : Index of the symmetry operation to apply (``1 \le \text{sym\_index} \le N_\text{sym}``)
+- `buffer` : Optional Bumper.jl buffer for stack allocations
+
+## Example
+
+```julia
+n_sym = get_nsymmetries(sym_group)
+avg = zeros(3, 3)
+rotated = zeros(3, 3)
+for i in 1:n_sym
+    rotate_matrix!(rotated, stress_tensor, cell, reciprocal_vectors, sym_group, i)
+    avg .+= rotated
+end
+avg ./= n_sym  # symmetrized stress tensor
+```
+
+## See also
+
+- [`rotate_dynamical_matrix!`](@ref) — for extensive ``n_\text{modes} \times n_\text{modes}`` matrices with atom-block structure
+- [`symmetrize_fc!`](@ref) — symmetrize a force constant matrix in real space (Cartesian)
+"""
+function rotate_matrix!(new_matrix :: AbstractMatrix{T}, old_matrix :: AbstractMatrix{T}, cell :: Matrix{T},
+        reciprocal_vectors :: Matrix{T}, symmetry_group :: Symmetries, sym_index :: Int; buffer=default_buffer()) where T
+
+    n_dims = get_dimensions(symmetry_group)
+
+    @no_escape buffer begin
+        tmp_matrix = @alloc(T, n_dims, n_dims)
+        work = @alloc(T, n_dims, n_dims)
+
+        # Convert to crystal: treat as a single-atom (n_atoms=1) block
+        cart_cryst_matrix_conversion!(tmp_matrix, old_matrix, cell; cart_to_cryst=true, buffer=buffer)
+
+        # Apply rotation: new = S' * old_cryst * S
+        sym_mat = symmetry_group.symmetries[sym_index]
+        mul!(work, tmp_matrix, sym_mat)
+        mul!(new_matrix, sym_mat', work)
+
+        # new_matrix is now in crystal coords, convert back to cartesian
+        tmp_matrix .= new_matrix
+        cart_cryst_matrix_conversion!(new_matrix, tmp_matrix, cell; cart_to_cryst=false, buffer=buffer)
+
+        nothing
+    end
+end
+function rotate_matrix!(new_matrix :: AbstractMatrix{T}, old_matrix :: AbstractMatrix{T}, cell :: Matrix{T},
+        reciprocal_vectors :: Matrix{T}, symmetry_group :: SymmetriesQSpace, sym_index :: Int; buffer=default_buffer()) where T
+    # Delegate to the Symmetries version — stress tensor is intensive (q-independent)
+    rotate_matrix!(new_matrix, old_matrix, cell, reciprocal_vectors, symmetry_group.symmetries, sym_index; buffer=buffer)
+end
+
+
+@doc raw"""
+    rotate_dynamical_matrix!(new_matrix :: AbstractMatrix{T}, old_matrix :: AbstractMatrix{T}, cell :: Matrix{T},
+            reciprocal_vectors :: Matrix{T},
+            symmetry_group :: Symmetries, sym_index :: Int; buffer=default_buffer()) where T
+    rotate_dynamical_matrix!(new_matrix :: AbstractArray{Complex{T}, 3}, old_matrix :: AbstractArray{Complex{T}, 3}, cell :: Matrix{T},
+            reciprocal_vectors :: Matrix{T},
+            symmetry_group :: SymmetriesQSpace, sym_index :: Int; buffer=default_buffer()) where T
+
+Apply a **single** symmetry operation on a dynamical matrix (force-constant-like
+matrix with atom blocks). The matrix must be provided in Cartesian coordinates;
+the conversion to crystal coordinates and back is handled internally.
+
+**Real-space version** — the matrix has size
+``(n_\text{modes}, n_\text{modes})`` where ``n_\text{modes} = n_\text{dims} \times n_\text{atoms}``.
+Each ``n_\text{dims} \times n_\text{dims}`` block ``(a, b)`` is rotated by the
+symmetry and the atom indices are permuted according to `irt`:
+
+```math
+\Phi'_{\text{irt}[a],\, \text{irt}[b]} = S^\top\, \Phi_{a b}\, S
+```
+
+**Q-space version** — the matrix has size ``(n_\text{modes}, n_\text{modes}, n_q)``.
+In addition to the block-wise rotation and atom permutation, the q-point is
+also permuted and phase factors from fractional translations are included:
+
+```math
+D'_{\text{irt}[a],\, \text{irt}[b]}(q')
+= e^{2\pi i\, q \cdot (\vec t_a - \vec t_b)}\,
+  S^\top\, D_{a b}(q)\, S
+```
+
+where ``q' = S^{-T} q`` and ``\vec t_a`` are the unit-cell translations
+that bring the symmetry-transformed atom back into the primitive cell.
+
+To symmetrize a dynamical matrix, call this function for each symmetry and
+average the result. That is equivalent to what `symmetrize_fc!` (real space)
+or `symmetrize_matrix_cartesian_q!` (q space) do internally.
+
+## Parameters
+
+- `new_matrix` : Output rotated matrix (modified in-place)
+- `old_matrix` : Input matrix to be rotated
+- `cell` : Primitive cell matrix (lattice vectors as columns)
+- `reciprocal_vectors` : Reciprocal lattice vectors (column-wise)
+- `symmetry_group` : The symmetry group (`Symmetries` or `SymmetriesQSpace`)
+- `sym_index` : Index of the symmetry operation to apply (``1 \le \text{sym\_index} \le N_\text{sym}``)
+- `buffer` : Optional Bumper.jl buffer for stack allocations
+
+## Example
+
+```julia
+n_sym = get_nsymmetries(sym_group)
+avg = zeros(n_modes, n_modes)
+rotated = zeros(n_modes, n_modes)
+for i in 1:n_sym
+    rotated .= 0
+    rotate_dynamical_matrix!(rotated, fc, cell, reciprocal_vectors, sym_group, i)
+    avg .+= rotated
+end
+avg ./= n_sym  # same as symmetrize_fc!(fc, cell, sym_group)
+```
+
+## See also
+
+- [`symmetrize_fc!`](@ref) — symmetrize a force constant matrix in real space (Cartesian)
+- [`symmetrize_matrix_cartesian_q!`](@ref) — symmetrize a dynamical matrix in q space (Cartesian)
+- [`rotate_matrix!`](@ref) — for intensive ``n_\text{dims} \times n_\text{dims}`` matrices (stress, dielectric)
+"""
+function rotate_dynamical_matrix!(new_matrix :: AbstractMatrix{T}, old_matrix :: AbstractMatrix{T}, cell :: Matrix{T},
+        reciprocal_vectors :: Matrix{T}, symmetry_group :: Symmetries, sym_index :: Int; buffer=default_buffer()) where T
+
+    n_dims = get_dimensions(symmetry_group)
+    n_modes = size(old_matrix, 1)
+    n_atoms = n_modes ÷ n_dims
+    new_matrix .= zero(T)
+
+    @no_escape buffer begin
+        tmp_matrix = @alloc(T, n_modes, n_modes)
+
+        # Convert Cartesian -> crystal
+        cart_cryst_matrix_conversion!(tmp_matrix, old_matrix, cell; cart_to_cryst=true, buffer=buffer)
+
+        # Apply symmetry (handles atom permutation and block-wise rotation)
+        apply_sym_fc!(new_matrix, tmp_matrix, symmetry_group.symmetries[sym_index], n_dims, symmetry_group.irt[sym_index]; buffer=buffer)
+
+        # Convert crystal -> Cartesian
+        tmp_matrix .= new_matrix
+        cart_cryst_matrix_conversion!(new_matrix, tmp_matrix, cell; cart_to_cryst=false, buffer=buffer)
+
+        nothing
+    end
+end
+function rotate_dynamical_matrix!(new_matrix :: AbstractArray{Complex{T}, 3}, old_matrix :: AbstractArray{Complex{T}, 3}, cell :: Matrix{T},
+        reciprocal_vectors :: Matrix{T}, symmetry_group :: SymmetriesQSpace, sym_index :: Int; buffer=default_buffer()) where T
+
+    n_dims = get_dimensions(symmetry_group)
+    n_modes = size(old_matrix, 1)
+    n_q = size(old_matrix, 3)
+    new_matrix .= zero(Complex{T})
+
+    @no_escape buffer begin
+        tmp_matrix = @alloc(Complex{T}, n_modes, n_modes, n_q)
+
+        # Convert Cartesian -> crystal (3D version loops over q-slices)
+        cart_cryst_matrix_conversion!(tmp_matrix, old_matrix, cell; cart_to_cryst=true, buffer=buffer)
+
+        # Apply symmetry (handles atom + q-point permutation + phase factors)
+        apply_symmetry_matrixq!(new_matrix, tmp_matrix,
+                                symmetry_group[sym_index],
+                                symmetry_group.symmetries.irt[sym_index],
+                                symmetry_group.irt_q[sym_index],
+                                symmetry_group.symmetries.unit_cell_translations[sym_index],
+                                symmetry_group.q_points;
+                                buffer=buffer)
+
+        # Convert crystal -> Cartesian
+        tmp_matrix .= new_matrix
+        cart_cryst_matrix_conversion!(new_matrix, tmp_matrix, cell; cart_to_cryst=false, buffer=buffer)
+
+        nothing
+    end
+end

--- a/src/crystal.jl
+++ b/src/crystal.jl
@@ -174,6 +174,9 @@ end
 In-place conversion of coordinates between crystallographic and Cartesian systems,
 supporting both real and reciprocal (q) space.
 
+This function supports multiple targets and sources to be converted at once (like many atoms or q-points)
+by passing them as array of shape `(n_dims, n_atoms)` or `(n_dims, n_q)`
+
 The function performs one of four transformations based on the boolean flags
 `cryst_to_cart` and `q_space`. It computes `target = α * T * source`, where
 `T` is the transformation matrix and `α` is a scaling factor.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,3 +88,12 @@ end
     include("test_fractional_symmetries.jl")
     test_fractional_symmetries_qspace()
 end
+
+include("test_general_interface.jl")
+@testset "General interface" begin
+    test_rotate_vector_real()
+    test_rotate_matrix_real()
+    test_rotate_dynamical_matrix_real()
+    test_rotate_vector_qspace()
+    test_rotate_dynamical_matrix_qspace()
+end

--- a/test/test_general_interface.jl
+++ b/test/test_general_interface.jl
@@ -1,0 +1,249 @@
+using AtomicSymmetries
+using LinearAlgebra
+using Test
+
+
+function test_rotate_vector_real(; verbose=false)
+    # Use PbTe unit cell (non-orthogonal, 2 atoms)
+    a = 12.21
+    cell = collect([-a 0.0 a; 0.0 a a; -a a 0.0]')
+    positions = collect([0.0 0.0 0.0; 0.4 0.4 0.4]')
+
+    sym_group = get_symmetry_group_from_spglib(positions, cell, [1, 2])
+    n_sym = get_nsymmetries(sym_group)
+    n_dims = 3
+    n_atoms = 2
+    n_modes = n_dims * n_atoms
+
+    reciprocal_vectors = zeros(Float64, 3, 3)
+    get_reciprocal_lattice!(reciprocal_vectors, cell)
+
+    # Create a random vector and symmetrize via rotate_vector! + averaging
+    old_vector = randn(Float64, n_modes)
+    asr! = ASRConstraint!(n_dims)
+    asr!(old_vector)
+
+    avg_vector = zeros(Float64, n_modes)
+    new_vector = zeros(Float64, n_modes)
+    for i in 1:n_sym
+        new_vector .= 0
+        rotate_vector!(new_vector, old_vector, cell, reciprocal_vectors, sym_group, i)
+        avg_vector .+= new_vector
+    end
+    avg_vector ./= n_sym
+
+    # Compare with the existing symmetrize_vector!
+    ref_vector = copy(old_vector)
+    symmetrize_vector!(ref_vector, cell, sym_group)
+
+    if verbose
+        println("rotate_vector avg: ", avg_vector)
+        println("symmetrize_vector: ", ref_vector)
+        println("diff: ", maximum(abs.(avg_vector - ref_vector)))
+    end
+
+    @test isapprox(avg_vector, ref_vector; atol=1e-10)
+end
+
+
+function test_rotate_matrix_real(; verbose=false)
+    # Use a cubic BCC cell
+    a = 2.87
+    cell = [a 0.0 0.0
+            0.0 a 0.0
+            0.0 0.0 a]
+    positions = [0.0 0.5
+                 0.0 0.5
+                 0.0 0.5]
+    types = [1, 1]
+
+    sym_group = get_symmetry_group_from_spglib(positions, cell, types)
+    n_sym = get_nsymmetries(sym_group)
+
+    reciprocal_vectors = zeros(Float64, 3, 3)
+    get_reciprocal_lattice!(reciprocal_vectors, cell)
+
+    # Create a random 3x3 matrix (stress tensor)
+    old_matrix = randn(Float64, 3, 3)
+    old_matrix .= (old_matrix .+ old_matrix') ./ 2  # Make symmetric
+
+    avg_matrix = zeros(Float64, 3, 3)
+    new_matrix = zeros(Float64, 3, 3)
+    for i in 1:n_sym
+        new_matrix .= 0
+        rotate_matrix!(new_matrix, old_matrix, cell, reciprocal_vectors, sym_group, i)
+        avg_matrix .+= new_matrix
+    end
+    avg_matrix ./= n_sym
+
+    # For a cubic cell, the symmetrized stress tensor should be proportional to identity
+    trace_val = tr(avg_matrix) / 3
+    expected = trace_val * I(3)
+
+    if verbose
+        println("Symmetrized stress tensor:")
+        println(avg_matrix)
+        println("Expected (proportional to I): ", trace_val, " * I")
+        println("diff: ", maximum(abs.(avg_matrix - expected)))
+    end
+
+    @test isapprox(avg_matrix, expected; atol=1e-10)
+end
+
+
+function test_rotate_dynamical_matrix_real(; verbose=false)
+    # Use PbTe unit cell
+    a = 12.21
+    cell = collect([-a 0.0 a; 0.0 a a; -a a 0.0]')
+    positions = collect([0.0 0.0 0.0; 0.4 0.4 0.4]')
+
+    sym_group = get_symmetry_group_from_spglib(positions, cell, [1, 2])
+    n_sym = get_nsymmetries(sym_group)
+    n_dims = 3
+    n_atoms = 2
+    n_modes = n_dims * n_atoms
+
+    reciprocal_vectors = zeros(Float64, 3, 3)
+    get_reciprocal_lattice!(reciprocal_vectors, cell)
+
+    # Create a random force constant matrix
+    old_fc = randn(Float64, n_modes, n_modes)
+    old_fc .= (old_fc .+ old_fc') ./ 2  # Make symmetric
+
+    avg_fc = zeros(Float64, n_modes, n_modes)
+    new_fc = zeros(Float64, n_modes, n_modes)
+    for i in 1:n_sym
+        new_fc .= 0
+        rotate_dynamical_matrix!(new_fc, old_fc, cell, reciprocal_vectors, sym_group, i)
+        avg_fc .+= new_fc
+    end
+    avg_fc ./= n_sym
+
+    # Compare with the existing symmetrize_fc!
+    ref_fc = copy(old_fc)
+    symmetrize_fc!(ref_fc, cell, sym_group)
+
+    if verbose
+        println("diff: ", maximum(abs.(avg_fc - ref_fc)))
+    end
+
+    @test isapprox(avg_fc, ref_fc; atol=1e-10)
+end
+
+
+function test_rotate_vector_qspace(; verbose=false)
+    # Use a tetragonal cell with 2 atoms (lower symmetry → non-trivial symmetrized vector)
+    a = 3.0
+    c = 4.5
+    unit_cell = [a 0.0 0.0; 0.0 a 0.0; 0.0 0.0 c]
+    positions = [0.0 0.5; 0.0 0.5; 0.0 0.3]  # atom 2 at general z → non-trivial result
+    types = [1, 2]
+
+    symmetry_group_uc = get_symmetry_group_from_spglib(positions, unit_cell, types)
+
+    reciprocal_lattice = zeros(Float64, 3, 3)
+    get_reciprocal_lattice!(reciprocal_lattice, unit_cell)
+
+    # Build q-points on a 2x2x2 grid
+    nq_side = 2
+    nq = nq_side^3
+    q_points_cryst = zeros(Float64, 3, nq)
+    iq = 0
+    for ix in 0:nq_side-1
+        for iy in 0:nq_side-1
+            for iz in 0:nq_side-1
+                iq += 1
+                q_points_cryst[:, iq] = [ix / nq_side, iy / nq_side, iz / nq_side]
+            end
+        end
+    end
+
+    symmetry_group_q = SymmetriesQSpace(symmetry_group_uc, q_points_cryst)
+    n_sym = length(symmetry_group_q)
+
+    n_dims = 3
+    n_atoms = 2
+    n_modes = n_dims * n_atoms
+
+    # Create a random complex vector in q-space (Cartesian)
+    old_vector = randn(Complex{Float64}, n_modes, nq)
+
+    # Compute rotate_vector! average over all symmetries
+    avg_vector = zeros(Complex{Float64}, n_modes, nq)
+    new_vector = zeros(Complex{Float64}, n_modes, nq)
+    for i in 1:n_sym
+        new_vector .= 0
+        rotate_vector!(new_vector, old_vector, unit_cell, reciprocal_lattice, symmetry_group_q, i)
+        avg_vector .+= new_vector
+    end
+    avg_vector ./= n_sym
+
+    # Compare at gamma with symmetrize_vector_cartesian_q!
+    # (it converts cart→cryst, calls symmetrize_vector_q!, converts back)
+    ref_vector = copy(old_vector)
+    symmetrize_vector_cartesian_q!(ref_vector, unit_cell, symmetry_group_q)
+
+    if verbose
+        println("n_sym = ", n_sym)
+        println("rotate avg at gamma: ", real.(avg_vector[:, 1]))
+        println("symmetrize at gamma: ", real.(ref_vector[:, 1]))
+        println("diff at gamma: ", maximum(abs.(real.(avg_vector[:, 1]) - real.(ref_vector[:, 1]))))
+    end
+
+    # Compare real parts at gamma (symmetrize_vector_cartesian_q! returns real gamma)
+    @test isapprox(real.(avg_vector[:, 1]), real.(ref_vector[:, 1]); atol=1e-10)
+    # Check that result is non-trivial (not all zeros)
+    @test maximum(abs.(real.(ref_vector[:, 1]))) > 1e-12
+end
+
+
+function test_rotate_dynamical_matrix_qspace(; verbose=false)
+    # Use the same setup as test_symmetrize_cartesian_qspace
+    q_tot = [0.0 -0.08970485720864457 -0.08970485720864457 0.0 -0.08970485720864457 -0.08970485720864457 -0.0 0.0; 0.0 -0.05179112345678227 0.05179112345678227 0.10358224691409373 0.05179112345678227 -0.05179112345678227 -0.10358224691409373 0.0; 0.0 0.07324370920331642 -0.07324370920331642 0.07324370920331642 0.03662185460165821 -0.03662185460165821 0.03662185460165821 -0.10986556380497464]
+
+    unit_cell_structure = zeros(Float64, 3, 1)
+    unit_cell = [2.94954603 1.4747730150000002 1.4747730150000002; 0.0 2.554381791611538 0.8514605972038461; 0.0 0.0 2.408294248783948]
+    unit_cell .*= 1.889725989
+
+    symmetry_group_uc = get_symmetry_group_from_spglib(unit_cell_structure, unit_cell, [1])
+
+    reciprocal_lattice = zeros(Float64, 3, 3)
+    get_reciprocal_lattice!(reciprocal_lattice, unit_cell)
+
+    q_points_cryst = zeros(Float64, size(q_tot)...)
+    cryst_cart_conv!(q_points_cryst, q_tot, unit_cell, reciprocal_lattice, false; q_space=true)
+
+    symmetry_group_q = SymmetriesQSpace(symmetry_group_uc, q_points_cryst)
+    n_sym = length(symmetry_group_q)
+
+    n_dims = 3
+    n_atoms = 1
+    n_modes = n_dims * n_atoms
+    nq = size(q_tot, 2)
+
+    # Create a random complex dynamical matrix in q-space
+    old_matrix = randn(Complex{Float64}, n_modes, n_modes, nq)
+    # Make Hermitian at each q
+    for iq in 1:nq
+        old_matrix[:, :, iq] .= (old_matrix[:, :, iq] .+ old_matrix[:, :, iq]') ./ 2
+    end
+
+    avg_matrix = zeros(Complex{Float64}, n_modes, n_modes, nq)
+    new_matrix = zeros(Complex{Float64}, n_modes, n_modes, nq)
+    for i in 1:n_sym
+        new_matrix .= 0
+        rotate_dynamical_matrix!(new_matrix, old_matrix, unit_cell, reciprocal_lattice, symmetry_group_q, i)
+        avg_matrix .+= new_matrix
+    end
+    avg_matrix ./= n_sym
+
+    # Compare with symmetrize_matrix_cartesian_q!
+    ref_matrix = copy(old_matrix)
+    symmetrize_matrix_cartesian_q!(ref_matrix, unit_cell, symmetry_group_q)
+
+    if verbose
+        println("diff: ", maximum(abs.(avg_matrix - ref_matrix)))
+    end
+
+    @test isapprox(avg_matrix, ref_matrix; atol=1e-10)
+end


### PR DESCRIPTION
This pull requests add support for dividing a spacegroup into a subgroup + cosets.
This is very useful to implement symmetrizations of perturbations that divide the original spacegroup in such a way and require a different treatment for symmetries that keep the perturbation invariant and symmetries that don't.

Also implement a new general interface for the application of symmetries that works with all kinds of space groups.