### PR TITLE
Redefine Fourier transform in the atomic-position phase gauge exp(2πiq·(R+τ))

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AtomicSymmetries"
 uuid = "7e24f7a5-8a44-4f91-9a93-7ee03df51e54"
 authors = ["Lorenzo Monacelli <mesonepigreco@gmail.com>"]
-version = "0.11.1"
+version = "0.12.0"
 
 [deps]
 Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"

--- a/docs/src/fourier_symmetries.md
+++ b/docs/src/fourier_symmetries.md
@@ -7,13 +7,32 @@ This is implemented now for force-constant dynamical matrices and vectors (displ
 A vector is transformed from real to q-space with the following convention:
 
 ```math
-\tilde v_k(\vec q) = \frac{1}{\sqrt{N_q}} \sum_{R} e^{-i 2\pi \vec R\cdot \vec q} v_k(\vec R)
+\tilde v_a(\vec q) = \frac{1}{\sqrt{N_q}} \sum_{R} e^{-i 2\pi \vec q\cdot (\vec R + \vec\tau_a)} v_a(\vec R)
 ```
 
 ```math
-v_k(\vec R) = \frac{1}{\sqrt{N_q}} \sum_{R} e^{i 2\pi \vec R\cdot \vec q} \tilde v_k(\vec q)
+v_a(\vec R) = \frac{1}{\sqrt{N_q}} \sum_{\vec q} e^{i 2\pi \vec q\cdot(\vec R + \vec\tau_a)} \tilde v_a(\vec q)
 ```
 
+where ``\vec\tau_a`` is the position of the atom ``a`` inside the primitive cell,
+so that ``\vec R + \vec\tau_a`` is the equilibrium position of the atom in the supercell.
+
+The phase factor employs the atomic positions ``\vec R + \vec\tau_a`` and not only
+the origin ``\vec R`` of the cell each atom belongs to. This is a gauge choice:
+the two conventions are related by the atom-dependent rephasing
+``e^{-2i\pi \vec q\cdot\vec\tau_a}``. The atomic-position gauge is adopted
+(since version 0.12) because it makes the Fourier transformed quantities smooth
+functions of ``\vec q``, which is much better suited for interpolating
+quantities in q space. The price to pay is that quantities in this gauge are
+**not periodic in the Brillouin zone**:
+
+```math
+\tilde v_a(\vec q + \vec G) = e^{-2i\pi \vec G\cdot \vec\tau_a}\, \tilde v_a(\vec q)
+```
+
+This must be carefully accounted for whenever a q point is folded back into the
+grid by a reciprocal lattice vector ``\vec G`` (this occurs when applying symmetries,
+see below).
 
 Note the sign of the Fourier and the normalization prefactor. 
 This convention allows for correctly transforming the matrices, however, it introduces a size inconsistency on the vectors.
@@ -23,12 +42,18 @@ the value in the primitive cell. So be carefull when extracting ``\Gamma`` point
 With this convention, we recover the standard rule for the matrices.
 
 ```math
-\tilde \Phi_{ab}(\vec q) = \sum_{\vec R} e^{2\pi i \vec q\cdot \vec R}\Phi_{a;b + \vec R}
+\tilde \Phi_{ab}(\vec q) = \sum_{\vec R} e^{2\pi i \vec q\cdot (\vec R + \vec\tau_a - \vec\tau_b)}\Phi_{a + \vec R;b}
 ```
 
 ```math
 \Phi_{ab} = \frac{1}{N_q} \sum_{\vec q}
-\tilde\Phi_{ab}(\vec  q) e^{2i\pi \vec q\cdot[\vec R(a) - \vec R(b)]}
+\tilde\Phi_{ab}(\vec  q) e^{2i\pi \vec q\cdot[(\vec R(a) + \vec\tau_a) - (\vec R(b) + \vec\tau_b)]}
+```
+
+As for the vectors, the matrix in this gauge is not periodic in the Brillouin zone:
+
+```math
+\tilde\Phi_{ab}(\vec q + \vec G) = e^{2i\pi \vec G\cdot(\vec\tau_a - \vec\tau_b)}\, \tilde\Phi_{ab}(\vec q)
 ```
 
 Note that these transformation of matrices and vector are consistent so that matrices and vector written as outer product can be consistently transformed
@@ -44,10 +69,10 @@ Note that these transformation of matrices and vector are consistent so that mat
 Notably, this convention introduces two main properties that must be handled with care.
 The ``\Gamma`` value of the fourier transform is not the average over the supercell of the same
 quantity. If you want to obtain the average, you must divide by ``\sqrt {N_q}`` (the number of q-points).
-If the `R_lat` is not centered around zero, and the coordinates passed as `v_sc` are absolute values of positions,
-then the ``\Gamma`` value of the fourier transform will be shifted by a total translation which is the average of the translations of the supercell lattice
-vectors.
-This can be avoided by either removing the corner of the supercell from the positions before performing the fourier transform, by centering R_lat around 0,
+If the coordinates passed as `v_sc` are absolute values of positions,
+then the ``\Gamma`` value of the fourier transform will be shifted by a total translation which is the average of the equilibrium positions.
+This can be avoided by passing `absolute_positions = true` (which subtracts the
+equilibrium positions ``\vec R + \vec\tau_a`` before transforming),
 or by removing this translational average *a posteriori* using the method `shift_position_origin!`.
 
 
@@ -82,6 +107,8 @@ Due to time-inversion symmetry, the dynamical matrix must also satisfy the condi
 D(q) = D^\dagger(-q + G)
 ``
 
+(where, in the atomic-position phase gauge, the folding by ``G`` introduces the block
+phase factor ``e^{2i\pi \vec G\cdot(\vec\tau_a - \vec\tau_b)}``, see `impose_hermitianity_q!`),
 therefore it is necessary also to keep track, for each q point, which one is the corresponding ``-q + G`` in the mesh. This mapping is computed by the helper function `get_minus_q!`. All these information needs to be stored when applying symmetries. Therefore we defined a new Symmetries struct that ihnerits from the `GenericSymmetries` called `SymmetriesQSpace`. Note that, to initialize the symmetries in q-space, we **must** use the symmetries object (`Symmetries`) evaluated in the primitive cell. The correct initialization of symmetries could be checked with the subroutine `check_symmetries`, which will spot if a different cell has been employed when initializing the symmetries.
 
 Since the q points must be passed in crystal coordinates, it may be useful to get the reciprocal lattice, which can be done with ``get_reciprocal_lattice!`` (see section on crystal coordinates for the API)
@@ -99,52 +126,65 @@ D(q, q') = D(q)\delta(q - q')
 
 This means that applying each symmetry operation in ``q`` space is equivalent to averaging the result of the same symmetry operation in the supercell averaging among all possible translations.
 
-The application of a symmetry in q space can be performed by considering how the force-constant matrix transform in real space under a symmetry operation ``S``.
+The application of a symmetry in q space can be performed by considering how the force-constant matrix transforms in real space under a symmetry operation ``\{S | \vec v\}`` (rotation ``S`` plus fractional translation ``\vec v``, in crystal coordinates).
+
+In the atomic-position phase gauge the derivation is particularly simple.
+The symmetry maps the equilibrium position of the atom ``a`` in the cell ``\vec R``
+into the equilibrium position of the atom ``s(a)`` in another cell:
 
 ```math
-S[\tilde\Phi_{ab}(\bm q)] = \sum_{\bm R} e^{2\pi i \bm q\cdot \bm R}S^\dagger\Phi_{S\bm a, S(\bm b + \bm R)}S
-```
-The transformation also changes which atoms are considered. However, we must be careful with the convention adopted for the Fourier transform. In fact, we have
-that $\bm a$ and $\bm b$ are the positions on the atom in the primitive cell considered. The vectors $S\bm a$ and $S(\bm b + \bm R)$ may not correspond to atoms in the primitive cell, but rather folded in the supercell. 
-To solve this issue, we need to define, for each symmetry operation, which atom in the primitive cell is mapped into which other atom in the primitive cell. This is indicated with ``s(a)`` and ``s(b)``. Also, we need to consider
-what is the translation vector ``\bm t_{s,a}`` that brings the vector ``S\bm a`` inside the primitive cell. With this information, we can rewrite the transformation as
-```math
-\bm t_{s,a} = S\bm a - \bm{s(a)}
+S(\vec R + \vec\tau_a) + \vec v = \vec R\,' + \vec \tau_{s(a)}
 ```
 
-```math
-S[\tilde\Phi_{ab}(\bm q)] = \sum_{\bm R} e^{2\pi i \bm q\cdot \bm R}S^\dagger\Phi_{s(a) + \bm t_{s,a}, s(b) + \bm t_{s, b} + S\bm R}S
-```
-
-Exploiting the translational invariance, we can remove the $\bm t_{s,a}$ vector from the first index of the supercell force constant matrix, and rewrite the expression as
-
+Since the phase factors of the Fourier transform are computed exactly from these
+equilibrium positions, the phases follow the atoms through the symmetry
+operation, and the transformation of the dynamical matrix takes the form
 
 ```math
-S[\tilde\Phi_{ab}(\bm q)] = \sum_{\bm R} e^{2\pi i \bm q\cdot \bm R}S^\dagger\Phi_{s(a), s(b) + \bm t_{s, b} - \bm t_{s, a} + S\bm R}S
-```
-By defining ``\bm R' = \bm t_{s, b} - \bm t_{s, a} + S\bm R``, we can rewrite the summation in ``\bm R'`` as
-
-
-```math
-S[\tilde\Phi_{ab}(\bm q)] = \sum_{\bm R'} e^{2\pi i \bm q\cdot S^{-1} (\bm R' + \bm t_{s,a} - \bm t_{s,b})}S^\dagger\Phi_{s(a), s(b) + \bm R'}S
-```
-Since we work in crystal coordinates and reciprocal vectors, ``S^{-1}\neq S^\dagger``. Therefore, we have
-
-```math
-S[\tilde\Phi_{ab}(\bm q)] = \sum_{\bm R'} e^{2\pi i [(\bm S^{-1})^\dagger\bm q]\cdot(\bm R' + \bm t_{s,a} - \bm t_{s,b})}S^\dagger\Phi_{s(a), s(b) + \bm R'}S
-```
-
-Which is equivalent to the Fourier transform of the dynamical matrix at the transformed q-point ``(\bm S^{-1})^\dagger\bm q``, times a phase factor.
-This is how symmetries operates in q space:
-```math
+S[\tilde\Phi_{ab}(\bm q)] = S^\dagger\, \tilde\Phi_{s(a)s(b)}(S_\text{recip}\bm q)\, S,
+\qquad
 \bm S_\text{recip} = \left(\bm S^{-1}\right)^\dagger
 ```
 
+with **no phase factor** associated with the fractional translations: the phases
+``e^{-2i\pi (S_\text{recip}\bm q)\cdot \vec v}`` picked up by the two displacement
+vectors cancel between the two atomic indices (this is one of the advantages of
+this gauge with respect to the lattice one, where a phase factor
+``e^{2\pi i \bm q\cdot(\bm t_{s,a} - \bm t_{s,b})}`` involving the unit-cell
+translations ``\bm t_{s,a} = S\vec\tau_a + \vec v - \vec\tau_{s(a)}`` appears).
+
+However, in this gauge the dynamical matrix is **not periodic** in the reciprocal
+lattice. The vector ``S_\text{recip}\bm q`` may fall outside the q grid, and it is
+folded back into the grid point ``\bm q_{\text{grid}}`` by a reciprocal lattice
+vector ``\bm G``:
+
 ```math
-S[\tilde\Phi_{ab}(\bm q)] = S^\dagger \tilde\Phi_{s(a)s(b)}(S_\text{recip}\bm q) S e^{2\pi i (S_\text{recip}\bm q)\cdot ( \bm t_{s,a} - \bm t_{s,b})}
+S_\text{recip}\bm q = \bm q_{\text{grid}} + \bm G
 ```
 
-Note that the ``S_\text{recip}q`` vector in the phase factor and in the dynamical matrix can be always folded back into the first Brilluin zone. In fact the dynamical matrix is periodic in the reciprocal vector, while the phase factor is multiplied by a direct lattice vector. Thus, by adding a reciprocal lattice vector ``\bm G`` to ``S_\text{recip}\bm q``, the phase factor is multiplied by ``e^{2\pi i \bm G\cdot ( \bm t_{s,a} - \bm t_{s,b})}``, which is always equal to 1.
+The folding introduces the phase factor
+
+```math
+\tilde\Phi_{s(a)s(b)}(\bm q_\text{grid} + \bm G) = e^{2\pi i \bm G\cdot(\vec\tau_{s(a)} - \vec\tau_{s(b)})}\, \tilde\Phi_{s(a)s(b)}(\bm q_\text{grid})
+```
+
+which is computed and applied automatically by `apply_symmetry_matrixq!`.
+For this reason, the atomic positions inside the primitive cell (in crystal
+coordinates) must be provided when initializing `SymmetriesQSpace`, and they
+must be the same positions employed in the Fourier transform (choosing a
+different periodic image of an atom changes the gauge).
+
+For vectors, the fractional translation phase does not cancel, and the
+transformation reads
+
+```math
+S[\tilde v_{a}(\bm q)] = e^{-2\pi i (S_\text{recip}\bm q)\cdot \vec v}\,
+e^{2\pi i \bm G\cdot \vec\tau_{s(a)}}\, S\, \tilde v_{a}(\bm q)
+```
+
+These phases are applied by `apply_symmetry_vectorq!` when the positions, the
+q points and the fractional translation are provided (they are automatically
+provided when using the general interface `rotate_vector!`).
 
 The application of symmetries is handled by the general function `rotate_vector!` and `rotate_dynamical_matrix!` or `rotate_matrix!` that works exactly like for real space symmetries, with the same general interface. However, we also provide specific q-space only functions. Note that, while the `rotate_*` functions works in cartesian space, the following one expects symmetries in real space.
 

--- a/src/apply_symmetry_general_interface.jl
+++ b/src/apply_symmetry_general_interface.jl
@@ -24,8 +24,14 @@ and the operation applies the symmetry rotation plus the atom permutation:
 operation additionally permutes q-points according to the symmetry:
 
 ```math
-\vec v'_{\text{irt}[a]}(q') = S\, \vec v_{a}(q), \qquad q' = S^{-T} q
+\vec v'_{\text{irt}[a]}(q') = e^{-2\pi i\, q'\cdot \vec v}\, S\, \vec v_{a}(q), \qquad q' = S^{-T} q
 ```
+
+where ``\vec v`` is the fractional translation of the symmetry. Since the
+vectors in q space follow the atomic-position phase gauge (see
+[`vector_r2q!`](@ref)), whenever ``S^{-T}q`` is folded back into the q grid by
+a reciprocal lattice vector ``\vec G``, the additional phase
+``e^{2\pi i \vec G\cdot \vec\tau_{\text{irt}[a]}}`` is applied.
 
 To symmetrize a vector (average over all symmetries), call this function for
 each symmetry and average the result. That is equivalent to what
@@ -108,9 +114,17 @@ function rotate_vector!(new_vector :: AbstractMatrix{Complex{T}}, old_vector :: 
                          reshape(old_vector, n_dims, :),
                          cell, reciprocal_vectors, false; q_space=false)
 
-        # Apply the matrix
+        # Apply the matrix (with the phase factors of the atomic-position gauge)
+        translation = nothing
+        if sym_index <= length(symmetry_group.symmetries.translations)
+            translation = symmetry_group.symmetries.translations[sym_index]
+        end
         apply_symmetry_vectorq!(new_vector, tmp_vector, symmetry_group[sym_index], symmetry_group.symmetries.irt[sym_index],
-                                symmetry_group.irt_q[sym_index])
+                                symmetry_group.irt_q[sym_index];
+                                positions=symmetry_group.positions,
+                                q_points=symmetry_group.q_points,
+                                translation=translation,
+                                buffer=buffer)
         tmp_vector .= new_vector
 
         # Convert back to cartesian
@@ -233,16 +247,19 @@ symmetry and the atom indices are permuted according to `irt`:
 
 **Q-space version** — the matrix has size ``(n_\text{modes}, n_\text{modes}, n_q)``.
 In addition to the block-wise rotation and atom permutation, the q-point is
-also permuted and phase factors from fractional translations are included:
+also permuted:
 
 ```math
 D'_{\text{irt}[a],\, \text{irt}[b]}(q')
-= e^{2\pi i\, q \cdot (\vec t_a - \vec t_b)}\,
-  S^\top\, D_{a b}(q)\, S
+= S^\top\, D_{a b}(q)\, S, \qquad q' = S^{-T} q
 ```
 
-where ``q' = S^{-T} q`` and ``\vec t_a`` are the unit-cell translations
-that bring the symmetry-transformed atom back into the primitive cell.
+Since the matrix in q space follows the atomic-position phase gauge (see
+[`matrix_r2q!`](@ref)), no phase factor from the fractional translations
+appears; however, whenever ``S^{-T}q`` is folded back into the q grid by a
+reciprocal lattice vector ``\vec G``, the folding phase
+``e^{2\pi i\, \vec G \cdot (\vec\tau_{\text{irt}[a]} - \vec\tau_{\text{irt}[b]})}``
+is applied (see [`apply_symmetry_matrixq!`](@ref)).
 
 To symmetrize a dynamical matrix, call this function for each symmetry and
 average the result. That is equivalent to what `symmetrize_fc!` (real space)
@@ -316,12 +333,12 @@ function rotate_dynamical_matrix!(new_matrix :: AbstractArray{Complex{T}, 3}, ol
         # Convert Cartesian -> crystal (3D version loops over q-slices)
         cart_cryst_matrix_conversion!(tmp_matrix, old_matrix, cell; cart_to_cryst=true, buffer=buffer)
 
-        # Apply symmetry (handles atom + q-point permutation + phase factors)
+        # Apply symmetry (handles atom + q-point permutation + folding phase factors)
         apply_symmetry_matrixq!(new_matrix, tmp_matrix,
                                 symmetry_group[sym_index],
                                 symmetry_group.symmetries.irt[sym_index],
                                 symmetry_group.irt_q[sym_index],
-                                symmetry_group.symmetries.unit_cell_translations[sym_index],
+                                symmetry_group.positions,
                                 symmetry_group.q_points;
                                 buffer=buffer)
 

--- a/src/filter_symmetries.jl
+++ b/src/filter_symmetries.jl
@@ -268,8 +268,9 @@ function CosetSymmetryGroup(original_group :: SymmetriesQSpace{T}, perturbation_
 
     # Wrap both subgroup and cosets in SymmetriesQSpace to compute irt_q
     q_points = original_group.q_points
-    subgroup_q = SymmetriesQSpace(real_coset.subgroup, q_points; buffer=buffer)
-    cosets_q = SymmetriesQSpace(real_coset.cosets, q_points; buffer=buffer)
+    positions = original_group.positions
+    subgroup_q = SymmetriesQSpace(real_coset.subgroup, q_points, positions; buffer=buffer)
+    cosets_q = SymmetriesQSpace(real_coset.cosets, q_points, positions; buffer=buffer)
 
     return CosetSymmetryGroup{SymmetriesQSpace{T}}(subgroup_q, cosets_q)
 

--- a/src/fourier_transform.jl
+++ b/src/fourier_transform.jl
@@ -3,26 +3,41 @@
     vector_r2q!(
         v_q :: AbstractArray{Complex{T}, 3},
         v_sc :: AbstractMatrix{T},
-        q_tot :: Matrix{T})
+        q :: Matrix{T},
+        itau :: Vector{I},
+        R_lat :: Matrix{T},
+        tau :: Matrix{T}
+    ) where {T <: AbstractFloat, I <: Integer}
     vector_r2q!(v_q :: AbstractArray{Complex{T}, 2},
         v_sc :: AbstractVector{T},
         q :: Matrix{T},
         itau :: Vector{I},
-        R_lat :: Matrix{T}
+        R_lat :: Matrix{T},
+        tau :: Matrix{T}
     ) where {T <: AbstractFloat, I <: Integer}
 
 
 Fourier transform a vector from real space and q space.
 
+The phase-factor convention (gauge) includes the atomic positions ``\vec \tau_a``
+inside the primitive cell:
+
 ``
 \displaystyle
-v_k(\vec q) = \frac{1}{\sqrt{N_q}} \sum_{R} e^{-i 2\pi \vec R\cdot \vec q} v_k(\vec R)
+v_a(\vec q) = \frac{1}{\sqrt{N_q}} \sum_{R} e^{-i 2\pi \vec q\cdot (\vec R + \vec\tau_a)} v_a(\vec R)
 ``
 
-It works both on a single vector and on a series of vector. 
+where ``\vec R + \vec \tau_a`` is the equilibrium position of the atom in the supercell.
+This gauge (in contrast with the one employing only ``\vec R``) makes the
+Fourier transformed quantities smooth functions of ``\vec q``, which is much
+better suited for interpolation in q space.
+Note that, as a consequence, quantities in this gauge are not periodic in the
+Brillouin zone: ``v_a(\vec q + \vec G) = e^{-2i\pi \vec G\cdot \vec\tau_a} v_a(\vec q)``.
+
+It works both on a single vector and on a series of vector.
 NOTE: In the latter case, the number
-of configurations must be in the first column. 
-This is not standard, 
+of configurations must be in the first column.
+This is not standard,
 but implemented in this way for performance reasons as
 it is the most convenient memory rapresentation for vectorizing the
 average calculation.
@@ -32,38 +47,43 @@ Notably, this convention introduces two main properties:
 The ``\Gamma`` value of the fourier transform is not the average over the supercell of the same
 quantity. If you want to obtain the average, you must divide by √nq (the number of q-points).
 
-If the `R_lat` is not centered around zero, and the coordinates passed as `v_sc` are absolute values of positions,
-then the ``\Gamma`` value of the fourier transform will be shifted by a total translation which is the average of the translations of the supercell lattice
-vectors.
+If the coordinates passed as `v_sc` are absolute values of positions,
+then the ``\Gamma`` value of the fourier transform will be shifted by a total translation
+proportional to the average of the equilibrium positions.
 
 To avoid this behaviour (which is wrong), you can use the option `absolute_positions`,
-which automatically rescales the `v_sc` to be coordinates relative
-to the respective cell origin identified by `R_lat`.
-Indeed, in this case, `R_lat` and `v_sc` must be of the same 
+which automatically rescales the `v_sc` to be displacements with respect to the
+equilibrium positions ``\vec R + \vec\tau_a``.
+Indeed, in this case, `R_lat`, `tau` and `v_sc` must be of the same
 units, and coordinate types (you cannot mix crystalline and cartesian).
 
 
 ## Parameters
 
-- `v_q` : (n_configs, 3nat, nq) 
+- `v_q` : (n_configs, 3nat, nq)
     The target vector in Fourier space. Optionally, n_configs could be omitted if transforming only 1 vector
 - `v_sc` : (n_configs, 3*nat_sc)
     The original vector in real space. Optionally, n_configs could be omitted if transforming only 1 vector
-- `q_tot` : (3, nq)
+- `q` : (3, nq)
     The list of q vectors
 - `itau` : (nat_sc)
     The correspondance for each atom in the supercell with the atom in the primitive cell.
 - `R_lat` : (3, nat_sc)
     The origin coordinates of the supercell in which the atom is
+- `tau` : (3, nat)
+    The positions of the atoms inside the primitive cell.
+    Must be expressed in the same units and coordinates as `R_lat`
+    (and dual to `q`, so that ``\vec q \cdot (\vec R + \vec\tau)`` is in units of 2π).
 - `absolute_positions` : Bool
-    If true [default false], removes from v_sc the value of R_lat.
+    If true [default false], removes from v_sc the equilibrium positions `R_lat + tau`.
 """
 function vector_r2q!(
         v_q :: AbstractArray{Complex{T}, 3},
         v_sc :: AbstractMatrix{T},
         q :: AbstractMatrix{T},
         itau :: AbstractVector{I},
-        R_lat :: AbstractMatrix{T};
+        R_lat :: AbstractMatrix{T},
+        tau :: AbstractMatrix{T};
         absolute_positions :: Bool = false
     ) where {T <: AbstractFloat, I <: Integer}
 
@@ -77,17 +97,18 @@ function vector_r2q!(
 
     for jq ∈ 1:nq
         for k ∈ 1:nat_sc
-            @views q_dot_R = q[:, jq]' * R_lat[:, k]
+            k_uc = itau[k]
+            @views q_dot_R = q[:, jq]' * R_lat[:, k] + q[:, jq]' * tau[:, k_uc]
             exp_value = exp(- 1im * 2π * q_dot_R)
 
             for α in 1:3
                 index_sc = 3 * (k - 1) + α
-                index_uc = 3 * (itau[k] - 1) + α
+                index_uc = 3 * (k_uc - 1) + α
                 @simd for i ∈ 1:n_random
-                    # Remove the absolute position if needed
+                    # Remove the equilibrium position if needed
                     δ_value = v_sc[i, index_sc]
                     if absolute_positions
-                        δ_value -= R_lat[α, k]
+                        δ_value -= R_lat[α, k] + tau[α, k_uc]
                     end
 
                     v_q[i, index_uc, jq] += exp_value * δ_value
@@ -103,11 +124,12 @@ function vector_r2q!(
         v_sc :: AbstractVector{T},
         q :: AbstractMatrix{T},
         itau :: AbstractVector{I},
-        R_lat :: AbstractMatrix{T};
+        R_lat :: AbstractMatrix{T},
+        tau :: AbstractMatrix{T};
         kwargs...
     ) where {T <: AbstractFloat, I <: Integer}
 
-    vector_r2q!(reshape(v_q, 1, size(v_q)...), reshape(v_sc, 1, size(v_sc)...), q, itau, R_lat; kwargs...)
+    vector_r2q!(reshape(v_q, 1, size(v_q)...), reshape(v_sc, 1, size(v_sc)...), q, itau, R_lat, tau; kwargs...)
 end
 
 
@@ -115,9 +137,10 @@ end
     vector_q2r!(
         v_sc :: AbstractMatrix{T},
         v_q :: AbstractArray{Complex{T}, 3},
-        q_tot :: Matrix{T},
+        q :: Matrix{T},
         itau :: Vector{I},
-        R_lat :: Matrix{T};
+        R_lat :: Matrix{T},
+        tau :: Matrix{T};
         absolute_positions :: Bool = false
         ) where {T <: AbstractFloat, I <: Integer}
     function vector_q2r!(
@@ -125,16 +148,20 @@ end
         v_q :: AbstractMatrix{Complex{T}},
         q :: Matrix{T},
         itau :: Vector{I},
-        R_lat :: Matrix{T};
+        R_lat :: Matrix{T},
+        tau :: Matrix{T};
         absolute_positions :: Bool = false
     ) where {T <: AbstractFloat, I <: Integer}
 
 
 Fourier transform a vector from q space to real space.
 
+The phase-factor convention (gauge) includes the atomic positions ``\vec\tau_a``
+inside the primitive cell (see [`vector_r2q!`](@ref)):
+
 ``
 \displaystyle
-v_k(\vec R) = \frac{1}{\sqrt{N_q}} \sum_{R} e^{+i 2\pi \vec R\cdot \vec q} v_k(\vec q)
+v_a(\vec R) = \frac{1}{\sqrt{N_q}} \sum_{\vec q} e^{+i 2\pi \vec q\cdot (\vec R + \vec \tau_a)} v_a(\vec q)
 ``
 
 It can be applied both to a single vector and in an ensemble.
@@ -147,23 +174,27 @@ This choice is made for performance reason in computing averages (exploiting vec
 
 - `v_sc` : (n_configs, 3*nat_sc)
     The target vector in real space. Optionally, n_configs can be omitted
-- `v_q` : (n_configs, nq, 3*nat) 
+- `v_q` : (n_configs, nq, 3*nat)
     The original vector in Fourier space. Optionally, n_configs can be omitted
-- `q_tot` : (3, nq)
+- `q` : (3, nq)
     The list of q vectors
 - `itau : (nat_sc)`
     The correspondance for each atom in the supercell with the atom in the primitive cell.
 - `R_lat : (3, nat_sc)`
     The origin coordinates of the supercell in which the atom is
+- `tau : (3, nat)`
+    The positions of the atoms inside the primitive cell
+    (same units and coordinates as `R_lat`).
 - `absolute_positions` : Bool
-    If true, add the absolute position of the cell to the transformed v_sc
+    If true, add the equilibrium positions `R_lat + tau` to the transformed v_sc
 """
 function vector_q2r!(
         v_sc :: AbstractMatrix{T},
         v_q :: AbstractArray{Complex{T}, 3},
         q :: AbstractMatrix{T},
         itau :: AbstractVector{I},
-        R_lat :: AbstractMatrix{T};
+        R_lat :: AbstractMatrix{T},
+        tau :: AbstractMatrix{T};
         absolute_positions :: Bool = false
     ) where {T <: AbstractFloat, I <: Integer}
 
@@ -173,24 +204,16 @@ function vector_q2r!(
     tmp_vector = zeros(Complex{T}, (n_random, 3*nat_sc))
 
     v_sc .= 0
-    if absolute_positions
-        for h in 1:nat_sc
-            for k in 1:3
-                δvalue = R_lat[k, h]
-                index = 3*(h-1) + k
-                v_sc[:, index] .+= δvalue
-            end
-        end
-    end
 
     for jq ∈ 1:nq
         for k ∈ 1:nat_sc
-            @views q_dot_R = q[:, jq]' * R_lat[:, k]
+            k_uc = itau[k]
+            @views q_dot_R = q[:, jq]' * R_lat[:, k] + q[:, jq]' * tau[:, k_uc]
             exp_value = exp(1im * 2π * q_dot_R)
 
             for α in 1:3
                 index_sc = 3 * (k - 1) + α
-                index_uc = 3 * (itau[k] - 1) + α
+                index_uc = 3 * (k_uc - 1) + α
                 @simd for i ∈ 1:n_random
                     tmp_vector[i, index_sc] += exp_value * v_q[i, index_uc, jq]
                 end
@@ -200,6 +223,17 @@ function vector_q2r!(
 
     v_sc .+= real(tmp_vector)
     v_sc ./= √(nq)
+
+    # Add the equilibrium positions (unscaled) if requested
+    if absolute_positions
+        for h in 1:nat_sc
+            for k in 1:3
+                δvalue = R_lat[k, h] + tau[k, itau[h]]
+                index = 3*(h-1) + k
+                v_sc[:, index] .+= δvalue
+            end
+        end
+    end
 end
 
 function vector_q2r!(
@@ -207,11 +241,12 @@ function vector_q2r!(
         v_q :: AbstractMatrix{Complex{T}},
         q :: AbstractMatrix{T},
         itau :: AbstractVector{I},
-        R_lat :: AbstractMatrix{T};
+        R_lat :: AbstractMatrix{T},
+        tau :: AbstractMatrix{T};
         kwargs...
     ) where {T <: AbstractFloat, I <: Integer}
 
-    vector_q2r!(reshape(v_sc, 1, size(v_sc)...), reshape(v_q, 1, size(v_q)...), q, itau, R_lat; kwargs...)
+    vector_q2r!(reshape(v_sc, 1, size(v_sc)...), reshape(v_q, 1, size(v_q)...), q, itau, R_lat, tau; kwargs...)
 end
 
 
@@ -221,20 +256,30 @@ end
         matrix_r :: AbstractMatrix{T},
         q :: Matrix{T},
         itau :: Vector{I},
-        R_lat :: Matrix{T})
+        R_lat :: Matrix{T},
+        tau :: Matrix{T})
 
 Fourier transform a matrix from real to q space
 
+The phase-factor convention (gauge) includes the atomic positions
+``\vec\tau_a`` inside the primitive cell:
+
 ```math
-M_{ab}(\vec q) = \sum_{\vec R} e^{2\pi i \vec q\cdot \vec R}\Phi_{a;b + \vec R}
+M_{ab}(\vec q) = \sum_{\vec R} e^{2\pi i \vec q\cdot (\vec R + \vec\tau_a - \vec\tau_b)}\Phi_{a + \vec R;b}
 ```
 
-Where ``\Phi_{ab}`` is the real space matrix, the ``b+\vec R`` indicates the corresponding atom in the supercell displaced by ``\vec R``. 
+Where ``\Phi_{ab}`` is the real space matrix, the ``a+\vec R`` indicates the corresponding atom in the supercell displaced by ``\vec R``.
+The phase is thus computed from the difference of the equilibrium positions of the
+two atoms, ``(\vec R_a + \vec\tau_a) - (\vec R_b + \vec\tau_b)``.
+This gauge makes ``M_{ab}(\vec q)`` a smooth function of ``\vec q``, better
+suited for the interpolation. As a consequence, the matrix is not periodic in
+the Brillouin zone:
+``M_{ab}(\vec q + \vec G) = e^{2i\pi \vec G\cdot(\vec\tau_a - \vec\tau_b)} M_{ab}(\vec q)``.
 
 
 ## Parameters
 
-- `matrix_q` : (3nat, 3nat, nq) 
+- `matrix_q` : (3nat, 3nat, nq)
     The target matrix in Fourier space.
 - `matrix_r` : (3*nat_sc, 3*nat)
     The original matrix in real space (supercell)
@@ -244,19 +289,23 @@ Where ``\Phi_{ab}`` is the real space matrix, the ``b+\vec R`` indicates the cor
     The correspondance for each atom in the supercell with the atom in the primitive cell.
 - `R_lat` : (3, nat_sc)
     The origin coordinates of the supercell in which the corresponding atom is
+- `tau` : (3, nat)
+    The positions of the atoms inside the primitive cell
+    (same units and coordinates as `R_lat`).
 """
 function matrix_r2q!(
         matrix_q :: AbstractArray{Complex{T}, 3},
         matrix_r :: AbstractMatrix{T},
         q :: Matrix{T},
         itau :: Vector{I},
-        R_lat :: Matrix{T}; buffer = default_buffer()) where {T, I<: Integer}
+        R_lat :: Matrix{T},
+        tau :: Matrix{T}; buffer = default_buffer()) where {T, I<: Integer}
     nq = size(q, 2)
     ndims = size(q, 1)
     nat_sc = size(matrix_r, 1) ÷ ndims
     nat = size(matrix_q, 1) ÷ ndims
 
-    matrix_q .= T(0.0) 
+    matrix_q .= T(0.0)
 
     @no_escape buffer begin
         ΔR⃗ = @alloc(T, ndims)
@@ -267,11 +316,13 @@ function matrix_r2q!(
         for iq in 1:nq
             for k_i in 1:nat
                 @simd for h_i in 1:nat_sc
-                    @views ΔR⃗ .= R_lat[:, k_i]
-                    @views ΔR⃗ .-= R_lat[:, h_i]
-                    @views q_dot_R = ΔR⃗' * q[:, iq]
-
                     h_i_uc = itau[h_i]
+
+                    @views ΔR⃗ .= R_lat[:, k_i]
+                    @views ΔR⃗ .+= tau[:, itau[k_i]]
+                    @views ΔR⃗ .-= R_lat[:, h_i]
+                    @views ΔR⃗ .-= tau[:, h_i_uc]
+                    @views q_dot_R = ΔR⃗' * q[:, iq]
 
                     exp_factor = exp(phase_i * q_dot_R)
                     @views tmp_mat .= matrix_r[(ndims*(h_i - 1) + 1 : ndims * h_i), (ndims*(k_i - 1) +1 : ndims*k_i)]
@@ -292,14 +343,18 @@ end
         matrix_q :: Array{Complex{T}, 3},
         q :: Matrix{T},
         itau :: Vector{Int},
-        R_lat :: Matrix{T})
+        R_lat :: Matrix{T},
+        tau :: Matrix{T})
 
 Fourier transform a matrix from q space into r space
+
+The phase-factor convention (gauge) includes the atomic positions
+``\vec\tau_a`` inside the primitive cell (see [`matrix_r2q!`](@ref)):
 
 ``
 \displaystyle
 \Phi_{ab} = \frac{1}{N_q} \sum_{\vec q}
-M_{ab}(\vec  q) e^{2i\pi \vec q\cdot[\vec R(a) - \vec R(b)]}
+M_{ab}(\vec  q) e^{2i\pi \vec q\cdot[(\vec R(a) + \vec\tau_a) - (\vec R(b) + \vec\tau_b)]}
 ``
 
 Where ``\Phi_{ab}`` is the real space matrix, ``M_{ab}(\vec q)`` is the q space matrix.
@@ -310,7 +365,7 @@ Where ``\Phi_{ab}`` is the real space matrix, ``M_{ab}(\vec q)`` is the q space 
 
 - matrix_r : (3*nat_sc, 3*nat)
     The target matrix in real space (supercell). If the second dimension is 3nat_sc, we also apply the translations
-- matrix_q : (3nat, 3nat, nq) 
+- matrix_q : (3nat, 3nat, nq)
     The original matrix in Fourier space.
 - q_tot : (3, nq)
     The list of q vectors
@@ -318,16 +373,20 @@ Where ``\Phi_{ab}`` is the real space matrix, ``M_{ab}(\vec q)`` is the q space 
     The correspondance for each atom in the supercell with the atom in the primitive cell.
 - R_lat : (3, nat_sc)
     The origin coordinates of the supercell in which the corresponding atom is
+- tau : (3, nat)
+    The positions of the atoms inside the primitive cell
+    (same units and coordinates as `R_lat`).
 - translations : Vector{Vector{Int}}
     The itau correspondance for each translational vector. Its size must be equal to the number of q point and
-    contain all possible translations. This can be obtained from the `get_translations` subroutine. 
+    contain all possible translations. This can be obtained from the `get_translations` subroutine.
 """
 function matrix_q2r!(
         matrix_r :: AbstractMatrix{T},
         matrix_q :: Array{Complex{T}, 3},
         q :: Matrix{T},
         itau :: Vector{I},
-        R_lat :: Matrix{T}; translations :: Union{Nothing, AbstractVector} = nothing, buffer = default_buffer()) where {T, I <: Integer}
+        R_lat :: Matrix{T},
+        tau :: Matrix{T}; translations :: Union{Nothing, AbstractVector} = nothing, buffer = default_buffer()) where {T, I <: Integer}
     nq = size(q, 2)
     ndims = size(q, 1)
     nat_sc = size(matrix_r, 1) ÷ ndims
@@ -361,11 +420,13 @@ function matrix_q2r!(
 
             for k_i in 1:nat
                 @simd for h_i in 1:nat_sc
-                    @views ΔR⃗ .= R_lat[:, k_i]
-                    @views ΔR⃗ .-= R_lat[:, h_i]
-                    @views q_dot_R = ΔR⃗' * q[:, iq]
-
                     h_i_uc = itau[h_i]
+
+                    @views ΔR⃗ .= R_lat[:, k_i]
+                    @views ΔR⃗ .+= tau[:, itau[k_i]]
+                    @views ΔR⃗ .-= R_lat[:, h_i]
+                    @views ΔR⃗ .-= tau[:, h_i_uc]
+                    @views q_dot_R = ΔR⃗' * q[:, iq]
 
                     exp_factor = exp(phase_i * q_dot_R)
                     #TODO: createa temporaney structure before adding the exponential otherwise itis not real
@@ -441,7 +502,7 @@ An example of usage after the fourier transform
 # Perform the fourier transform in q space
 # Here, we assume that R_lat and q_points are expressed in crystal coordinates.
 # Otherwise, just pass the identity to the cell below.
-vector_r2q!(positions_q, positions_r, q_points, itau, R_lat)
+vector_r2q!(positions_q, positions_r, q_points, itau, R_lat, tau)
 
 # Remove the translations
 shift_position_origin!(positions_q, cell, R_lat)

--- a/src/symmetrize_qspace.jl
+++ b/src/symmetrize_qspace.jl
@@ -1,40 +1,58 @@
 @doc raw"""
-    SymmetriesQSpace(symmetries :: Symmetries{T}, q_points :: AbstractMatrix{T}) :: SymmetriesQSpace{T} where T
+    SymmetriesQSpace(symmetries :: Symmetries{T}, q_points :: AbstractMatrix{T}, positions :: AbstractMatrix{T}) :: SymmetriesQSpace{T} where T
 
     struct SymmetriesQSpace{T} <: GenericSymmetries where T
         symmetries :: Symmetries{T}
+        q_points :: Matrix{T}
+        positions :: Matrix{T}
         irt_q :: Vector{Vector{Int}}
         minus_q_index :: Vector{Int}
     end
 
 This structure contains the information to perform the symmetrization of a dynamical matrix directly in q space.
 
-**Note that the `q_points` needs to be in crystal coordinates**,
+**Note that the `q_points` and the `positions` need to be in crystal coordinates**,
 
 and the symmetries must be of the primitive cell.
+
+The atomic `positions` are required because the Fourier transform is defined
+with the phase factor gauge ``e^{2i\pi \vec q\cdot(\vec R + \vec\tau_a)}``
+(see [`vector_r2q!`](@ref) and [`matrix_r2q!`](@ref)).
+In this gauge the q-space quantities are not periodic in the Brillouin zone:
+whenever a symmetry maps a q point outside the grid
+(``S^{-T}\vec q = \vec q' + \vec G``), the folding by the reciprocal lattice
+vector ``\vec G`` introduces phase factors depending on ``\vec G\cdot\vec\tau_a``.
+
+**Important**: the `positions` must be the same used to compute the Fourier
+transform (expressed in crystal coordinates); using a different periodic image of an atom changes the gauge.
 
 
 ## Parameters
 
 - `symmetries` : The symmetries of the primitive cell (Symmetries{T})
 - `q_points` : The q points where the symmetries must be applied (in crystal coordinates)
+- `positions` : The atomic positions in the primitive cell (in crystal coordinates); size (n_dims, n_atoms)
 - `irt_q` : A vector (one for each symmetry) of the correspondances of q points. For each symmetry can be obtained from `get_irt_q!`
     Q points linked in this way are related by the symmetry operation in reciprocal space, and belong to the same star of q.
 - `minus_q_index` : A vector containing for each `q` the corresponding ``\vec {q'} = -\vec q + \vec G``, where ``\vec G`` is a generic reciprocal lattice vector.
 """
-struct SymmetriesQSpace{T} <: GenericSymmetries 
+struct SymmetriesQSpace{T} <: GenericSymmetries
     symmetries :: Symmetries{T}
     q_points :: Matrix{T}
+    positions :: Matrix{T}
     irt_q :: Vector{Vector{Int}}
     minus_q_index :: Vector{Int}
 end
-function SymmetriesQSpace(symmetries :: Symmetries{T}, q_points :: AbstractMatrix{T}; buffer = default_buffer()) :: SymmetriesQSpace{T} where T
+function SymmetriesQSpace(symmetries :: Symmetries{T}, q_points :: AbstractMatrix{T}, positions :: AbstractMatrix{T}; buffer = default_buffer()) :: SymmetriesQSpace{T} where T
     n_symmetries = length(symmetries)
     n_q = size(q_points, 2)
     n_dims = size(q_points, 1)
 
     my_q_points = zeros(T, n_dims, n_q)
     my_q_points .= q_points
+
+    my_positions = zeros(T, size(positions)...)
+    my_positions .= positions
 
     irt_q = Vector{Vector{Int}}(undef, n_symmetries)
     for i in 1:n_symmetries
@@ -45,7 +63,7 @@ function SymmetriesQSpace(symmetries :: Symmetries{T}, q_points :: AbstractMatri
     minus_q_index = zeros(Int, n_q)
     get_minus_q!(minus_q_index, q_points)
 
-    SymmetriesQSpace(symmetries, my_q_points, irt_q, minus_q_index)
+    SymmetriesQSpace(symmetries, my_q_points, my_positions, irt_q, minus_q_index)
 end
 
 get_dimensions(x ::SymmetriesQSpace) = get_dimensions(x.symmetries)
@@ -94,38 +112,99 @@ end
 
 
 @doc raw"""
-    apply_symmetry_vectorq!(target_vector :: AbstractMatrix{Complex{T}}, original_vector :: AbstractMatrix{Complex{T}}, symmetry_operation :: AbstractMatrix{U}, irt :: Vector{Int}, irt_q:: AbstractVector{Int})
+    apply_symmetry_vectorq!(target_vector :: AbstractMatrix{Complex{T}}, original_vector :: AbstractMatrix{Complex{T}}, symmetry_operation :: AbstractMatrix{U}, irt :: Vector{Int}, irt_q:: AbstractVector{Int}; positions = nothing, q_points = nothing, translation = nothing, buffer = default_buffer())
 
 
-Apply the symmetry on the original vector in q space
+Apply the symmetry on the original vector in q space.
+
+The vector in q space is assumed in the phase factor gauge
+``e^{-2i\pi \vec q\cdot(\vec R + \vec\tau_a)}`` (see [`vector_r2q!`](@ref)).
+In this gauge the application of a symmetry ``\{S | \vec v\}`` reads
+
+```math
+v'_{s(a)}(S^{-T}\vec q) = e^{-2i\pi (S^{-T}\vec q)\cdot \vec v}\, S\, v_a(\vec q)
+```
+
+with no atom-dependent phase. However, when ``S^{-T}\vec q`` falls outside the
+q grid, it is folded back by a reciprocal lattice vector ``\vec G``
+(``S^{-T}\vec q = \vec q_{\text{grid}} + \vec G``), and, since in this gauge
+vectors are not periodic in the Brillouin zone, the folding introduces the extra
+phase ``e^{2i\pi \vec G\cdot \vec\tau_{s(a)}}``.
+
+If `positions` and `q_points` are provided (in crystal coordinates), all
+these phase factors are computed and applied. If they are omitted (default),
+no phase is applied: this is only correct if the result is used at ``\Gamma``
+(e.g. inside [`symmetrize_vector_q!`](@ref)), or when all the phases are
+trivial (symmorphic group, no folding).
 
 ## Parameters
 
 - `target_vector` : The result (modified inplace) (3n x nq)
 - `original_vector` : The original vector (3n x nq)
-- `symmetry_operation` : The 3x3 symmetry 
+- `symmetry_operation` : The 3x3 symmetry (crystal coordinates, direct space)
 - `irt` : The atom-atom association by symmetry
 - `irt_q` : The q-q association by symmetry
+- `positions` : The atomic positions in the primitive cell (crystal coordinates, n_dims x n_atoms) [Optional, keyword]
+- `q_points` : The q points (crystal coordinates, n_dims x nq) [Optional, keyword]
+- `translation` : The fractional translation ``\vec v`` of the symmetry (crystal coordinates) [Optional, keyword]
+- `buffer` : The Bumper.jl buffer for caching memory allocations [Optional, keyword]
 """
 function apply_symmetry_vectorq!(target_vector :: AbstractMatrix{Complex{T}}, original_vector :: AbstractMatrix{Complex{T}},
-        symmetry_operation :: AbstractMatrix{U}, irt :: AbstractVector{Int}, irt_q :: AbstractVector{Int}) where {T, U}
-    # Apply symmetries 
+        symmetry_operation :: AbstractMatrix{U}, irt :: AbstractVector{Int}, irt_q :: AbstractVector{Int};
+        positions :: Union{Nothing, AbstractMatrix{T}} = nothing,
+        q_points :: Union{Nothing, AbstractMatrix{T}} = nothing,
+        translation :: Union{Nothing, AbstractVector{T}} = nothing,
+        buffer = default_buffer()) where {T, U}
+    # Apply symmetries
     nq = length(irt_q)
     n_dims = size(symmetry_operation, 1)
     n_atoms = size(target_vector, 1) ÷ n_dims
 
+    apply_phases = positions !== nothing
+    if apply_phases && q_points === nothing
+        error("Error in apply_symmetry_vectorq!: if `positions` are provided, also `q_points` must be provided.")
+    end
 
-    for iq in 1:nq
-        jq = irt_q[iq]
-
-        for i in 1:n_atoms
-            j = irt[i]
-
-            @views mul!(target_vector[n_dims * (j - 1) + 1: n_dims * j, jq], 
-                        symmetry_operation, 
-                        original_vector[n_dims * (i - 1) + 1: n_dims * i, iq],
-                        T(1.0), T(1.0))
+    @no_escape buffer begin
+        atom_phases = @alloc(Complex{T}, n_atoms)
+        G_vect = @alloc(T, n_dims)
+        sym_rec = @alloc(T, n_dims, n_dims)
+        if apply_phases
+            sym_rec .= inv(symmetry_operation)'
         end
+
+        for iq in 1:nq
+            jq = irt_q[iq]
+
+            # Compute the phases due to the folding into the q grid
+            # G = S^{-T} q_iq - q_jq and the fractional translation
+            atom_phases .= Complex{T}(1)
+            if apply_phases
+                @views mul!(G_vect, sym_rec, q_points[:, iq])
+                translation_phase = Complex{T}(1)
+                if translation !== nothing
+                    # exact q' = S^{-T} q_iq = q_jq + G
+                    @views q_dot_v = G_vect' * translation
+                    translation_phase = exp(-1im * 2π * q_dot_v)
+                end
+                @views G_vect .-= q_points[:, jq]
+
+                for a in 1:n_atoms
+                    @views g_dot_tau = G_vect' * positions[:, a]
+                    atom_phases[a] = exp(1im * 2π * g_dot_tau) * translation_phase
+                end
+            end
+
+            for i in 1:n_atoms
+                j = irt[i]
+
+                @views mul!(target_vector[n_dims * (j - 1) + 1: n_dims * j, jq],
+                            symmetry_operation,
+                            original_vector[n_dims * (i - 1) + 1: n_dims * i, iq],
+                            atom_phases[j], Complex{T}(1.0))
+            end
+        end
+        nothing
     end
 end
 
@@ -135,22 +214,42 @@ end
         sym :: AbstractMatrix{U},
         irt :: AbstractVector{Int},
         irt_q :: AbstractVector{Int},
-        unit_cell_translations :: AbstractMatrix{T},
+        positions :: AbstractMatrix{T},
+        q_points :: AbstractMatrix{T}
         ; buffer = default_buffer()) where {T, U}
 
 
-Apply the symmetry on the matrix in q space
-This subroutine assumes the convention that the phase factor is for each supercell, not atoms.
-In other words, all the atoms coordinates are computed from the same origin of the supercell they are associated with.
+Apply the symmetry on the matrix in q space.
+
+The matrix in q space is assumed in the phase factor gauge
+``e^{2i\pi \vec q\cdot(\vec R + \vec\tau_a)}`` (see [`matrix_r2q!`](@ref)),
+where the phase factors are computed from the atomic positions, not from the
+origin of the supercell in which each atom lies.
+
+In this gauge, the application of a symmetry ``\{S | \vec v\}`` reads
+
+```math
+M'_{s(a)s(b)}(S^{-T}\vec q) = S\, M_{ab}(\vec q)\, S^T
+```
+
+with no phase factors coming from the fractional translations (they cancel
+between the two atoms). However, in this gauge the matrix is not periodic in
+the Brillouin zone: whenever ``S^{-T}\vec q`` falls outside the q grid and is
+folded back by a reciprocal lattice vector ``\vec G``
+(``S^{-T}\vec q = \vec q_{\text{grid}} + \vec G``), the folding introduces the
+phase factor ``e^{2i\pi \vec G\cdot(\vec\tau_{s(a)} - \vec\tau_{s(b)})}``,
+which is accounted for by this subroutine.
+Everything (symmetries, positions and q points) must be provided in crystal coordinates.
 
 ## Parameters
 
-- `target_vector` : The result (modified inplace) (3n x nq)
-- `original_vector` : The original vector (3n x nq)
-- `symmetry_operation` : The 3x3 symmetry 
+- `target_matrix` : The result (modified inplace) (3n x 3n x nq)
+- `original_matrix` : The original matrix (3n x 3n x nq)
+- `sym` : The 3x3 symmetry (crystal coordinates, direct space)
 - `irt` : The atom-atom association by symmetry
 - `irt_q` : The q-q association by symmetry
-- `unit_cell_translations` : The translation vectors to move the transformed atom in the primitive cell
+- `positions` : The atomic positions inside the primitive cell (crystal coordinates, n_dims x n_atoms). They must be the same positions used to compute the Fourier transform.
+- `q_points` : The q points (crystal coordinates, n_dims x nq)
 - `buffer` : The Bumper.jl buffer for caching memory allocations [Optional]
 """
 function apply_symmetry_matrixq!(target_matrix :: AbstractArray{Complex{T}, 3},
@@ -158,7 +257,7 @@ function apply_symmetry_matrixq!(target_matrix :: AbstractArray{Complex{T}, 3},
         sym :: AbstractMatrix{U},
         irt :: AbstractVector{Int},
         irt_q :: AbstractVector{Int},
-        unit_cell_translations :: AbstractMatrix{T},
+        positions :: AbstractMatrix{T},
         q_points :: AbstractMatrix{T}
         ; buffer = default_buffer()) where {T, U}
 
@@ -169,22 +268,38 @@ function apply_symmetry_matrixq!(target_matrix :: AbstractArray{Complex{T}, 3},
 
     @no_escape buffer begin
         work = @alloc(Complex{T}, n_dims, n_dims)
-        δt = @alloc(T, n_dims)
+        G_vect = @alloc(T, n_dims)
+        sym_rec = @alloc(T, n_dims, n_dims)
+        atom_phases = @alloc(Complex{T}, n_atoms)
+
+        # The symmetry in reciprocal space (q' = S^{-T} q)
+        sym_rec .= inv(sym)'
+
         for iq in 1:nq
             iq_s = irt_q[iq]
+
+            # Get the reciprocal lattice vector G that folds S^{-T}q_iq
+            # back into the grid point q_{iq_s}
+            @views mul!(G_vect, sym_rec, q_points[:, iq])
+            @views G_vect .-= q_points[:, iq_s]
+
+            # Phases due to the folding: e^{2πi G·τ_a}
+            for a in 1:n_atoms
+                @views g_dot_tau = G_vect' * positions[:, a]
+                atom_phases[a] = exp(1im * 2π * g_dot_tau)
+            end
+
             for i ∈ 1:n_atoms
                 i_s = irt[i]
-                for j in 1:n_atoms 
+                for j in 1:n_atoms
                     j_s = irt[j]
-                    @views δt .= unit_cell_translations[:, i_s] .- unit_cell_translations[:, j_s]
-                    @views q_dot_t = dot(q_points[:, iq], δt)
-                    @views phase_factor = exp(1im * 2π * q_dot_t)
+                    phase_factor = atom_phases[i_s] * conj(atom_phases[j_s])
 
-                    @views mul!(work, 
-                                original_matrix[n_dims*(i_s-1) + 1: n_dims*i_s, n_dims*(j_s-1)+1 : n_dims*j_s, iq_s], 
+                    @views mul!(work,
+                                original_matrix[n_dims*(i_s-1) + 1: n_dims*i_s, n_dims*(j_s-1)+1 : n_dims*j_s, iq_s],
                                 sym, T(1.0), T(0.0))
-                    @views mul!(target_matrix[n_dims*(i-1) + 1: n_dims*i, n_dims*(j - 1) + 1: n_dims*j, iq], 
-                        sym', work, phase_factor, 1.0)
+                    @views mul!(target_matrix[n_dims*(i-1) + 1: n_dims*i, n_dims*(j - 1) + 1: n_dims*j, iq],
+                        sym', work, phase_factor, Complex{T}(1.0))
                 end
             end
         end
@@ -445,11 +560,11 @@ The matrix must be in crystal coordinates.
 - `original_q` : The original matrix in q-space of size `n_modes, n_modes, nq`. It could be the same as target_q
 - `symmetries` : The symmetry group
 - `irt_q` : A vector (one for each symmetry) of the correspondances of q points. For each symmetry can be obtained from `get_irt_q!`
-- `unit_cell_translations` :: Vector{Matrix{T}} : The translations of the unit cell to bring back the atoms in the primitive cell after the symmetry operation. Each vector elements corresponds to one symmetry operation, then the matrix is a n_dims x n_atoms translation. This is usually the same as the content of `symmetries.unit_cell_translations`.
+- `positions` : The atomic positions in the primitive cell (crystal coordinates, n_dims x n_atoms). They must be the same positions used to compute the Fourier transform (see `apply_symmetry_matrixq!`).
 - `minus_q_index` : A vector containing for each `q` the corresponding ``\vec {q'} = -\vec q + \vec G``, where ``\vec G`` is a generic reciprocal lattice vector.
 - `q_points` : The vector containing the actual q points
 """
-function symmetrize_matrix_q!(target_q :: AbstractArray{Complex{T}, 3}, original_q :: AbstractArray{Complex{T}, 3}, symmetries :: Symmetries, irt_q :: Vector{Vector{Int}}, unit_cell_translations :: Vector{Matrix{T}}, minus_q_index::Vector{Int}, q_points :: AbstractMatrix{T}; buffer = default_buffer())  where T
+function symmetrize_matrix_q!(target_q :: AbstractArray{Complex{T}, 3}, original_q :: AbstractArray{Complex{T}, 3}, symmetries :: Symmetries, irt_q :: Vector{Vector{Int}}, positions :: AbstractMatrix{T}, minus_q_index::Vector{Int}, q_points :: AbstractMatrix{T}; buffer = default_buffer())  where T
 
     n_modes = size(original_q, 1)
     n_q = size(original_q, 3)
@@ -464,13 +579,7 @@ function symmetrize_matrix_q!(target_q :: AbstractArray{Complex{T}, 3}, original
             irt = symmetries.irt[i]
             q_irt = irt_q[i]
 
-            #println("Applying symmetry $i")
-            #println("Symmetry matrix:")
-            #println(sym_mat)
-            #@show q_irt
-            #@show unit_cell_translations[i]
-
-            apply_symmetry_matrixq!(tmp_matrix, original_q, sym_mat, irt, q_irt, unit_cell_translations[i], q_points; buffer=buffer)
+            apply_symmetry_matrixq!(tmp_matrix, original_q, sym_mat, irt, q_irt, positions, q_points; buffer=buffer)
         end
 
         tmp_matrix ./= length(symmetries)
@@ -498,7 +607,7 @@ function symmetrize_matrix_q!(target_q :: AbstractArray{Complex{T}, 3}, original
     end
 end
 function symmetrize_matrix_q!(target_q :: AbstractArray{Complex{T}, 3}, original_q :: AbstractArray{Complex{T}, 3}, q_symmetries :: SymmetriesQSpace; buffer = default_buffer())  where T
-    symmetrize_matrix_q!(target_q, original_q, q_symmetries.symmetries, q_symmetries.irt_q, q_symmetries.symmetries.unit_cell_translations, q_symmetries.minus_q_index, q_symmetries.q_points; buffer=buffer)
+    symmetrize_matrix_q!(target_q, original_q, q_symmetries.symmetries, q_symmetries.irt_q, q_symmetries.positions, q_symmetries.minus_q_index, q_symmetries.q_points; buffer=buffer)
 end
 function symmetrize_matrix_q!(matrix_q :: AbstractArray{Complex{T}, 3}, q_symmetries :: SymmetriesQSpace; buffer = default_buffer())  where T
     @no_escape buffer begin
@@ -558,28 +667,83 @@ end
 
 
 @doc raw"""
+    impose_hermitianity_q!(matrix_q :: AbstractArray{Complex{T}, 3}, minus_q_index, positions :: AbstractMatrix{T}, q_points :: AbstractMatrix{T}; buffer=default_buffer()) where T
+    impose_hermitianity_q!(matrix_q :: AbstractArray{Complex{T}, 3}, q_symmetries :: SymmetriesQSpace{T}; buffer=default_buffer()) where T
     impose_hermitianity_q!(matrix_q :: AbstractArray{Complex{T}, 3}, minus_q_index; buffer=default_buffer()) where T
 
 Impose the hermitianity and time-reversal symmetry on the dynamical matrix in q space.
+
+The matrix in q space is assumed in the phase factor gauge
+``e^{2i\pi \vec q\cdot(\vec R + \vec\tau_a)}`` (see [`matrix_r2q!`](@ref)).
+In this gauge the time-reversal constraint ``M_{ab}(-\vec q) = M_{ab}(\vec q)^*``
+still holds exactly; however, since ``-\vec q`` is stored in the grid at
+``\vec q_j = -\vec q + \vec G_m``, and the matrix is not periodic in the
+Brillouin zone, the folding introduces the block phase factor
+``e^{2i\pi \vec G_m\cdot(\vec\tau_a - \vec\tau_b)}``.
+For this reason the atomic `positions` and the `q_points`
+(both in crystal coordinates) are needed.
+
+The method accepting only `minus_q_index` does not apply any folding phase:
+it is correct only when all the phases are trivial (e.g. all the atoms sit
+at the origin of the cell, or the q grid is closed under inversion without folding, like a grid centered around ``\Gamma``).
 
 ## Parameters
 
 - `matrix_q` : The dynamical matrix in q space (modified inplace)
 - `minus_q_index` : A vector containing for each `q` the corresponding ``\vec {q'} = -\vec q + \vec G``, where ``\vec G`` is a generic reciprocal lattice vector.
+- `positions` : The atomic positions in the primitive cell (crystal coordinates, n_dims x n_atoms). They must be the same positions used to compute the Fourier transform.
+- `q_points` : The q points (crystal coordinates, n_dims x nq)
+- `q_symmetries` : The symmetries in q space (contains `minus_q_index`, `positions` and `q_points`)
 
 """
-function impose_hermitianity_q!(matrix_q :: AbstractArray{Complex{T}, 3}, minus_q_index :: AbstractVector{Int}; buffer=default_buffer()) where T
+function impose_hermitianity_q!(matrix_q :: AbstractArray{Complex{T}, 3}, minus_q_index :: AbstractVector{Int},
+        positions :: Union{Nothing, AbstractMatrix{T}}, q_points :: Union{Nothing, AbstractMatrix{T}}; buffer=default_buffer()) where T
     n_q = size(matrix_q, 3)
     n_modes = size(matrix_q, 1)
+
+    apply_phases = positions !== nothing
+    if apply_phases && q_points === nothing
+        error("Error in impose_hermitianity_q!: if `positions` are provided, also `q_points` must be provided.")
+    end
+
+    n_dims = apply_phases ? size(positions, 1) : 0
+    n_atoms = apply_phases ? size(positions, 2) : 0
+
     @no_escape buffer begin
         target_q = @alloc(Complex{T}, size(matrix_q)...)
+        phases = @alloc(Complex{T}, n_modes, n_modes, n_q)
+        G_vect = apply_phases ? (@alloc(T, n_dims)) : (@alloc(T, 1))
+        atom_phases = apply_phases ? (@alloc(Complex{T}, n_atoms)) : (@alloc(Complex{T}, 1))
 
-        # Apply the hermitianity
+        # Compute the block phases e^{2πi G_m·(τ_a - τ_b)} with G_m = q_iq + q_{minus_q_index[iq]}
+        phases .= Complex{T}(1)
+        if apply_phases
+            for iq in 1:n_q
+                @views G_vect .= q_points[:, iq] .+ q_points[:, minus_q_index[iq]]
+                for a in 1:n_atoms
+                    @views g_dot_tau = G_vect' * positions[:, a]
+                    atom_phases[a] = exp(1im * 2π * g_dot_tau)
+                end
+                for b in 1:n_atoms
+                    for a in 1:n_atoms
+                        block_phase = atom_phases[a] * conj(atom_phases[b])
+                        for β in 1:n_dims
+                            for α in 1:n_dims
+                                phases[n_dims*(a-1) + α, n_dims*(b-1) + β, iq] = block_phase
+                            end
+                        end
+                    end
+                end
+            end
+        end
+
+        # Impose the symmetry of the real-space matrix:
+        # M_ab(q) = phase_ab * M_ba(-q)
         for iq in 1:n_q
             for h in 1:n_modes
                 for k in 1:n_modes
                     target_q[k,h, iq] = matrix_q[k, h, iq]
-                    target_q[k,h, iq] += matrix_q[h, k, minus_q_index[iq]]
+                    target_q[k,h, iq] += phases[k, h, iq] * matrix_q[h, k, minus_q_index[iq]]
                 end
             end
         end
@@ -589,11 +753,23 @@ function impose_hermitianity_q!(matrix_q :: AbstractArray{Complex{T}, 3}, minus_
         # Apply the time-reversal symmetry
         matrix_q .= target_q
         for iq in 1:n_q
-            @views target_q[:, :, iq] .+= conj.(matrix_q[:, :, minus_q_index[iq]]')
+            jq = minus_q_index[iq]
+            for h in 1:n_modes
+                for k in 1:n_modes
+                    target_q[k, h, iq] += phases[k, h, iq] * matrix_q[h, k, jq]
+                end
+            end
         end
         target_q ./= T(2)
         matrix_q .= target_q
+        nothing
     end
+end
+function impose_hermitianity_q!(matrix_q :: AbstractArray{Complex{T}, 3}, minus_q_index :: AbstractVector{Int}; buffer=default_buffer()) where T
+    impose_hermitianity_q!(matrix_q, minus_q_index, nothing, nothing; buffer=buffer)
+end
+function impose_hermitianity_q!(matrix_q :: AbstractArray{Complex{T}, 3}, q_symmetries :: SymmetriesQSpace{T}; buffer=default_buffer()) where T
+    impose_hermitianity_q!(matrix_q, q_symmetries.minus_q_index, q_symmetries.positions, q_symmetries.q_points; buffer=buffer)
 end
 
 @doc raw"""

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -89,6 +89,16 @@ end
     test_fractional_symmetries_qspace()
 end
 
+@testset "Fourier gauge" begin
+    # Tests of the atomic-position phase gauge e^{2πi q·(R + τ)}
+    include("test_fourier_gauge.jl")
+    test_gauge_phase_relation()
+    test_gauge_roundtrip()
+    test_gauge_symmetry_application()
+    test_gauge_vector_symmetry()
+    test_gauge_hermitianity()
+end
+
 include("test_general_interface.jl")
 @testset "General interface" begin
     test_rotate_vector_real()

--- a/test/test_coset_decomposition.jl
+++ b/test/test_coset_decomposition.jl
@@ -101,7 +101,7 @@ function test_coset_decomposition_qspace(; verbose=false)
     q_points = Float64[0 0.5 0 0 0.5 0.5 0 0.5;
                        0 0 0.5 0 0.5 0 0.5 0.5;
                        0 0 0 0.5 0 0.5 0.5 0.5]
-    q_group = SymmetriesQSpace(original_group, q_points)
+    q_group = SymmetriesQSpace(original_group, q_points, positions)
 
     n_original = length(q_group)
     if verbose

--- a/test/test_filter.jl
+++ b/test/test_filter.jl
@@ -105,7 +105,7 @@ function test_filter_fourier(; verbose=false)
     symmetry_group = get_symmetry_group_from_spglib(crystal, cell, types)
 
     # Convert the symmetry group in q space = 
-    q_symmetry_group = SymmetriesQSpace(symmetry_group, q_points)
+    q_symmetry_group = SymmetriesQSpace(symmetry_group, q_points, crystal)
 
     # Filter the invariant symmetries
     filter_invariant_symmetries!(q_symmetry_group, polarization_vector, cell)

--- a/test/test_fourier_gauge.jl
+++ b/test/test_fourier_gauge.jl
@@ -1,0 +1,369 @@
+using AtomicSymmetries
+using LinearAlgebra
+using Random
+using Test
+
+# Test suite for the atomic-position phase gauge of the Fourier transform:
+#
+#   v_a(q) ~ e^{-2πi q·(R + τ_a)},   M_ab(q) ~ e^{+2πi q·(R_a + τ_a - R_b - τ_b)}
+#
+# The tests use a CsCl-like structure (simple cubic, atom 1 at the origin,
+# atom 2 at (0.5, 0.5, 0.5) with a different type) on a 2x2x2 supercell.
+# This structure has the full Oh point group (including inversion), and since
+# τ₂ = (½,½,½) is nontrivial, the q-grid foldings S^{-T}q = q' + G generate
+# nontrivial phase factors e^{2πi G·τ} = -1: the sign conventions of all the
+# phases are therefore actually exercised.
+function get_cscl_supercell()
+    a = 3.1
+    cell = [a 0.0 0.0
+            0.0 a 0.0
+            0.0 0.0 a]
+    positions = [0.0 0.5
+                 0.0 0.5
+                 0.0 0.5]
+    types = [1, 2]
+
+    supercell = [2, 2, 2]
+    nat = size(positions, 2)
+    ndims = 3
+    n_sc = prod(supercell)
+    nat_sc = nat * n_sc
+
+    R_lat = zeros(Float64, ndims, nat_sc)
+    q_vec = zeros(Float64, ndims, n_sc)
+    super_cell = zeros(Float64, ndims, ndims)
+    super_positions = zeros(Float64, ndims, nat_sc)
+    super_types = ones(Int, nat_sc)
+    super_itau = zeros(Int, nat_sc)
+
+    for i in 1:ndims
+        @views super_cell[:, i] .= cell[:, i] * supercell[i]
+    end
+
+    counter = 1
+    for i in 1:supercell[1]
+        for j in 1:supercell[2]
+            for k in 1:supercell[3]
+                latvec = [i-1, j-1, k-1] ./ supercell
+                @views q_vec[:, counter] .= latvec
+
+                for h in 1:nat
+                    R_lat[:, nat * (counter - 1) + h] = latvec .* supercell
+                    super_positions[:, nat * (counter - 1) + h] = positions[:, h] ./ supercell + latvec
+                    super_itau[nat * (counter - 1) + h] = h
+                end
+                counter += 1
+            end
+        end
+    end
+
+    for iat in 1:nat_sc
+        super_types[iat] = types[super_itau[iat]]
+    end
+
+    return (cell = cell, positions = positions, types = types,
+            supercell = supercell, super_cell = super_cell,
+            super_positions = super_positions, super_types = super_types,
+            super_itau = super_itau, R_lat = R_lat, q_vec = q_vec)
+end
+
+
+# Build a random translation-invariant symmetric force-constant matrix
+function get_random_invariant_fc(super_positions, super_itau, supercell, super_cell, super_types)
+    Random.seed!(5678)
+    ndims, nat_sc = size(super_positions)
+
+    sc_group = get_symmetry_group_from_spglib(super_positions, super_cell, super_types)
+    translations = get_translations(sc_group)
+
+    fc = randn(Float64, ndims * nat_sc, ndims * nat_sc)
+    fc .+= fc'
+    apply_translations!(fc, translations)
+    return fc, translations
+end
+
+
+# Check that the new gauge is related to the lattice gauge (phases with R only)
+# by the rephasing M̃_ab(q) = e^{2πi q·(τ_a - τ_b)} M_ab(q)
+function test_gauge_phase_relation(; verbose=false)
+    s = get_cscl_supercell()
+    ndims = 3
+    nat = size(s.positions, 2)
+    nat_sc = size(s.super_positions, 2)
+    nq = size(s.q_vec, 2)
+
+    fc, translations = get_random_invariant_fc(s.super_positions, s.super_itau, s.supercell,
+                                               s.super_cell, s.super_types)
+
+    phi_q = zeros(ComplexF64, ndims*nat, ndims*nat, nq)
+    matrix_r2q!(phi_q, fc, s.q_vec, s.super_itau, s.R_lat, s.positions)
+
+    # Reference: lattice-gauge Fourier transform computed by hand
+    phi_q_lattice = zeros(ComplexF64, ndims*nat, ndims*nat, nq)
+    for iq in 1:nq
+        for k in 1:nat
+            for h in 1:nat_sc
+                h_uc = s.super_itau[h]
+                ΔR = s.R_lat[:, k] .- s.R_lat[:, h]
+                phase = exp(-2im * π * (s.q_vec[:, iq]' * ΔR))
+                @views phi_q_lattice[ndims*(h_uc-1)+1:ndims*h_uc, ndims*(k-1)+1:ndims*k, iq] .+=
+                    phase .* fc[ndims*(h-1)+1:ndims*h, ndims*(k-1)+1:ndims*k]
+            end
+        end
+    end
+
+    for iq in 1:nq
+        for b in 1:nat
+            for a in 1:nat
+                gauge_phase = exp(2im * π * (s.q_vec[:, iq]' * (s.positions[:, a] .- s.positions[:, b])))
+                @views expected = gauge_phase .* phi_q_lattice[ndims*(a-1)+1:ndims*a, ndims*(b-1)+1:ndims*b, iq]
+                @views @test isapprox(phi_q[ndims*(a-1)+1:ndims*a, ndims*(b-1)+1:ndims*b, iq],
+                                      expected; atol=1e-10)
+            end
+        end
+    end
+end
+
+
+# Round trip r -> q -> r -> q for the matrix and vector transforms
+function test_gauge_roundtrip(; verbose=false)
+    s = get_cscl_supercell()
+    ndims = 3
+    nat = size(s.positions, 2)
+    nat_sc = size(s.super_positions, 2)
+    nq = size(s.q_vec, 2)
+
+    fc, translations = get_random_invariant_fc(s.super_positions, s.super_itau, s.supercell,
+                                               s.super_cell, s.super_types)
+
+    phi_q = zeros(ComplexF64, ndims*nat, ndims*nat, nq)
+    phi_back = zeros(Float64, ndims*nat_sc, ndims*nat_sc)
+    phi_q_bis = similar(phi_q)
+
+    matrix_r2q!(phi_q, fc, s.q_vec, s.super_itau, s.R_lat, s.positions)
+    matrix_q2r!(phi_back, phi_q, s.q_vec, s.super_itau, s.R_lat, s.positions; translations=translations)
+    @test isapprox(phi_back, fc; atol=1e-10)
+
+    matrix_r2q!(phi_q_bis, phi_back, s.q_vec, s.super_itau, s.R_lat, s.positions)
+    @test isapprox(phi_q_bis, phi_q; atol=1e-10)
+
+    # Vector roundtrip
+    Random.seed!(91011)
+    u = randn(Float64, ndims * nat_sc)
+    u_q = zeros(ComplexF64, ndims*nat, nq)
+    u_back = zeros(Float64, ndims * nat_sc)
+    vector_r2q!(u_q, u, s.q_vec, s.super_itau, s.R_lat, s.positions)
+    vector_q2r!(u_back, u_q, s.q_vec, s.super_itau, s.R_lat, s.positions)
+    @test isapprox(u_back, u; atol=1e-10)
+
+    # absolute_positions: transforming (equilibrium + displacement) with
+    # absolute_positions=true must match transforming the displacement alone.
+    # Here everything is in (primitive) crystal coordinates: the equilibrium
+    # positions are R_lat + tau.
+    u_abs = copy(u)
+    for k in 1:nat_sc
+        @views u_abs[ndims*(k-1)+1:ndims*k] .+= s.R_lat[:, k] .+ s.positions[:, s.super_itau[k]]
+    end
+    u_q_abs = zeros(ComplexF64, ndims*nat, nq)
+    vector_r2q!(u_q_abs, u_abs, s.q_vec, s.super_itau, s.R_lat, s.positions; absolute_positions=true)
+    @test isapprox(u_q_abs, u_q; atol=1e-10)
+
+    # ... and the backward transform restores the absolute positions
+    u_back_abs = zeros(Float64, ndims * nat_sc)
+    vector_q2r!(u_back_abs, u_q_abs, s.q_vec, s.super_itau, s.R_lat, s.positions; absolute_positions=true)
+    @test isapprox(u_back_abs, u_abs; atol=1e-10)
+end
+
+
+# Apply each symmetry both in real space and in q space and compare.
+# Since τ₂ = (0.5, 0.5, 0.5) and the Oh group folds the q grid, the
+# G-folding phases are nontrivial here.
+function test_gauge_symmetry_application(; verbose=false)
+    s = get_cscl_supercell()
+    ndims = 3
+    nat = size(s.positions, 2)
+    nat_sc = size(s.super_positions, 2)
+    nq = size(s.q_vec, 2)
+
+    fc, translations = get_random_invariant_fc(s.super_positions, s.super_itau, s.supercell,
+                                               s.super_cell, s.super_types)
+
+    uc_group = get_symmetry_group_from_spglib(s.positions, s.cell, s.types)
+    n_sym = length(uc_group)
+    if verbose
+        println("Number of symmetries: $n_sym")
+    end
+    @test n_sym == 48
+
+    phi_q = zeros(ComplexF64, ndims*nat, ndims*nat, nq)
+    matrix_r2q!(phi_q, fc, s.q_vec, s.super_itau, s.R_lat, s.positions)
+
+    irt_q = zeros(Int, nq)
+    irt_sc = zeros(Int, nat_sc)
+    trans_vect = zeros(Float64, ndims, nat_sc)
+
+    phi_q_sym = similar(phi_q)
+    fc_sym = zeros(Float64, ndims*nat_sc, ndims*nat_sc)
+    phi_q_ref = similar(phi_q)
+
+    n_nontrivial_foldings = 0
+
+    for i_sym in 1:n_sym
+        sym_mat = uc_group.symmetries[i_sym]
+        AtomicSymmetries.get_irt_q!(irt_q, s.q_vec, sym_mat)
+
+        # Count the q points folded back with G != 0 (to make sure the phases matter)
+        sym_rec = inv(sym_mat)'
+        for iq in 1:nq
+            G = sym_rec * s.q_vec[:, iq] .- s.q_vec[:, irt_q[iq]]
+            if maximum(abs.(G)) > 1e-6
+                n_nontrivial_foldings += 1
+            end
+        end
+
+        # q-space application
+        phi_q_sym .= 0
+        AtomicSymmetries.apply_symmetry_matrixq!(phi_q_sym, phi_q, sym_mat,
+                                                 uc_group.irt[i_sym], irt_q,
+                                                 s.positions, s.q_vec)
+
+        # Real-space application
+        AtomicSymmetries.get_irt!(irt_sc, trans_vect, s.super_positions, sym_mat,
+                                  uc_group.translations[i_sym] ./ s.supercell)
+        fc_sym .= 0
+        AtomicSymmetries.apply_sym_fc!(fc_sym, fc, sym_mat, ndims, irt_sc)
+        apply_translations!(fc_sym, translations)
+
+        phi_q_ref .= 0
+        matrix_r2q!(phi_q_ref, fc_sym, s.q_vec, s.super_itau, s.R_lat, s.positions)
+
+        @test isapprox(phi_q_sym, phi_q_ref; atol=1e-8)
+    end
+
+    # The Oh group on the 2x2x2 grid must fold many q points outside the grid
+    @test n_nontrivial_foldings > 0
+    if verbose
+        println("Number of foldings with G != 0: $n_nontrivial_foldings")
+    end
+
+    # Full symmetrization: q space vs real space
+    q_symmetries = SymmetriesQSpace(uc_group, s.q_vec, s.positions)
+    phi_q_sym .= 0
+    symmetrize_matrix_q!(phi_q_sym, phi_q, q_symmetries)
+
+    sc_group = get_symmetry_group_from_spglib(s.super_positions, s.super_cell, s.super_types)
+    fc_sym .= fc
+    sc_group.symmetrize_fc!(fc_sym)
+    phi_q_ref .= 0
+    matrix_r2q!(phi_q_ref, fc_sym, s.q_vec, s.super_itau, s.R_lat, s.positions)
+
+    @test isapprox(phi_q_sym, phi_q_ref; atol=1e-8)
+
+    # Negative control: ignoring the atomic positions (i.e. using the
+    # lattice-gauge symmetrization on a new-gauge matrix) must give a
+    # different (wrong) result: the folding phases really matter here.
+    fake_positions = zeros(Float64, ndims, nat)
+    fake_q_symmetries = SymmetriesQSpace(uc_group, s.q_vec, fake_positions)
+    phi_q_wrong = similar(phi_q)
+    phi_q_wrong .= 0
+    symmetrize_matrix_q!(phi_q_wrong, phi_q, fake_q_symmetries)
+    @test maximum(abs.(phi_q_wrong .- phi_q_ref)) > 1e-6
+end
+
+
+# Apply each symmetry to a displacement field both in real space and in
+# q space (with the folding + fractional translation phases) and compare.
+function test_gauge_vector_symmetry(; verbose=false)
+    s = get_cscl_supercell()
+    ndims = 3
+    nat = size(s.positions, 2)
+    nat_sc = size(s.super_positions, 2)
+    nq = size(s.q_vec, 2)
+
+    uc_group = get_symmetry_group_from_spglib(s.positions, s.cell, s.types)
+    n_sym = length(uc_group)
+
+    Random.seed!(1213)
+    u = randn(Float64, ndims * nat_sc)
+    u_q = zeros(ComplexF64, ndims*nat, nq)
+    vector_r2q!(u_q, u, s.q_vec, s.super_itau, s.R_lat, s.positions)
+
+    irt_q = zeros(Int, nq)
+    irt_sc = zeros(Int, nat_sc)
+    trans_vect = zeros(Float64, ndims, nat_sc)
+    u_q_sym = similar(u_q)
+    u_sym = zeros(Float64, ndims * nat_sc)
+    u_q_ref = similar(u_q)
+
+    for i_sym in 1:n_sym
+        sym_mat = uc_group.symmetries[i_sym]
+        AtomicSymmetries.get_irt_q!(irt_q, s.q_vec, sym_mat)
+
+        # q-space application (with all the gauge phases)
+        u_q_sym .= 0
+        AtomicSymmetries.apply_symmetry_vectorq!(u_q_sym, u_q, sym_mat,
+                                                 uc_group.irt[i_sym], irt_q;
+                                                 positions=s.positions,
+                                                 q_points=s.q_vec,
+                                                 translation=uc_group.translations[i_sym])
+
+        # Real-space application (displacements: no translations applied to the values)
+        AtomicSymmetries.get_irt!(irt_sc, trans_vect, s.super_positions, sym_mat,
+                                  uc_group.translations[i_sym] ./ s.supercell)
+        u_sym .= 0
+        AtomicSymmetries.apply_sym_centroid!(u_sym, u, sym_mat, ndims, irt_sc)
+
+        u_q_ref .= 0
+        vector_r2q!(u_q_ref, u_sym, s.q_vec, s.super_itau, s.R_lat, s.positions)
+
+        @test isapprox(u_q_sym, u_q_ref; atol=1e-8)
+    end
+end
+
+
+# The Fourier transform of a real, symmetric, translation-invariant
+# force-constant matrix must already satisfy hermitianity + time reversal:
+# impose_hermitianity_q! must leave it unchanged (and be idempotent).
+function test_gauge_hermitianity(; verbose=false)
+    s = get_cscl_supercell()
+    ndims = 3
+    nat = size(s.positions, 2)
+    nq = size(s.q_vec, 2)
+
+    fc, translations = get_random_invariant_fc(s.super_positions, s.super_itau, s.supercell,
+                                               s.super_cell, s.super_types)
+
+    uc_group = get_symmetry_group_from_spglib(s.positions, s.cell, s.types)
+    q_symmetries = SymmetriesQSpace(uc_group, s.q_vec, s.positions)
+
+    phi_q = zeros(ComplexF64, ndims*nat, ndims*nat, nq)
+    matrix_r2q!(phi_q, fc, s.q_vec, s.super_itau, s.R_lat, s.positions)
+
+    phi_q_fixed = copy(phi_q)
+    impose_hermitianity_q!(phi_q_fixed, q_symmetries)
+    @test isapprox(phi_q_fixed, phi_q; atol=1e-10)
+
+    # Idempotency on a generic (random) matrix
+    Random.seed!(1415)
+    random_q = randn(ComplexF64, ndims*nat, ndims*nat, nq)
+    once = copy(random_q)
+    impose_hermitianity_q!(once, q_symmetries)
+    twice = copy(once)
+    impose_hermitianity_q!(twice, q_symmetries)
+    @test isapprox(twice, once; atol=1e-10)
+
+    # Negative control: without the positions, the folding phases are missed
+    # and the FT of a valid real-space matrix is (wrongly) modified
+    phi_q_wrong = copy(phi_q)
+    impose_hermitianity_q!(phi_q_wrong, q_symmetries.minus_q_index)
+    @test maximum(abs.(phi_q_wrong .- phi_q)) > 1e-6
+end
+
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    test_gauge_phase_relation(; verbose=true)
+    test_gauge_roundtrip(; verbose=true)
+    test_gauge_symmetry_application(; verbose=true)
+    test_gauge_vector_symmetry(; verbose=true)
+    test_gauge_hermitianity(; verbose=true)
+end

--- a/test/test_fractional_symmetries.jl
+++ b/test/test_fractional_symmetries.jl
@@ -61,8 +61,8 @@ function test_fractional_symmetries_qspace(; verbose=false)
     symmetries_uc = get_symmetry_group_from_spglib(cryst_coords, primitive_cell, types_uc)
 
     Φ_q = zeros(ComplexF64, n_dims * nat, n_dims * nat, n_q)
-    matrix_r2q!(Φ_q, Φ_sc, qpoints, itau, Rlat)
-    symmetries_qspace = SymmetriesQSpace(symmetries_uc, q_points)
+    matrix_r2q!(Φ_q, Φ_sc, qpoints, itau, Rlat, coords_uc)
+    symmetries_qspace = SymmetriesQSpace(symmetries_uc, q_points, cryst_coords)
 
 
     # Perform the symmetrization in real space and in q_space, then compare
@@ -82,7 +82,7 @@ function test_fractional_symmetries_qspace(; verbose=false)
 
     # Convert the supercell force constants to q space for comparison
     Φ_q_real_space_sym = zeros(ComplexF64, n_dims * nat, n_dims * nat, n_q)
-    matrix_r2q!(Φ_q_real_space_sym, Φ_sc, qpoints, itau, Rlat)
+    matrix_r2q!(Φ_q_real_space_sym, Φ_sc, qpoints, itau, Rlat, coords_uc)
 
     hplack = PhysicalConstants.CODATA2018.h
 
@@ -101,16 +101,28 @@ function test_fractional_symmetries_qspace(; verbose=false)
         end
         @test isapprox(Φ_q[:, :, i], Φ_q_real_space_sym[:, :, i]; atol=1e-10, rtol=1e-6)
 
+        # In the atomic-position phase gauge, the time-reversal relation between
+        # the stored q and -q + G picks up the block phase e^{2πi G·(τ_a - τ_b)}
+        j = symmetries_qspace.minus_q_index[i]
+        G_m = symmetries_qspace.q_points[:, i] .+ symmetries_qspace.q_points[:, j]
+        minus_q_phases = zeros(ComplexF64, n_dims * nat, n_dims * nat)
+        for b in 1:nat
+            for a in 1:nat
+                block_phase = exp(2im * π * (G_m' * (cryst_coords[:, a] .- cryst_coords[:, b])))
+                minus_q_phases[n_dims*(a-1)+1:n_dims*a, n_dims*(b-1)+1:n_dims*b] .= block_phase
+            end
+        end
+
         if verbose
-            delta_minus_q = maximum(abs.(Φ_q[:, :, i] - conj.(Φ_q[:, :, symmetries_qspace.minus_q_index[i]])))
-            println("iq = $i; -q mapped to iq = ", symmetries_qspace.minus_q_index[i])
+            delta_minus_q = maximum(abs.(Φ_q[:, :, j] - minus_q_phases .* conj.(Φ_q[:, :, i])))
+            println("iq = $i; -q mapped to iq = ", j)
             println("q = $(symmetries_qspace.q_points[:, i])")
-            println("minus q = $(symmetries_qspace.q_points[:, symmetries_qspace.minus_q_index[i]])")
+            println("minus q = $(symmetries_qspace.q_points[:, j])")
             println("Δ = $delta_minus_q")
             println()
         end
 
-        @test isapprox(Φ_q[:, :, i], conj.(Φ_q[:, :, symmetries_qspace.minus_q_index[i]]); rtol=1e-10, atol=1e-12)
+        @test isapprox(Φ_q[:, :, j], minus_q_phases .* conj.(Φ_q[:, :, i]); rtol=1e-10, atol=1e-12)
     end
 
 end

--- a/test/test_general_interface.jl
+++ b/test/test_general_interface.jl
@@ -158,7 +158,7 @@ function test_rotate_vector_qspace(; verbose=false)
         end
     end
 
-    symmetry_group_q = SymmetriesQSpace(symmetry_group_uc, q_points_cryst)
+    symmetry_group_q = SymmetriesQSpace(symmetry_group_uc, q_points_cryst, positions)
     n_sym = length(symmetry_group_q)
 
     n_dims = 3
@@ -213,7 +213,7 @@ function test_rotate_dynamical_matrix_qspace(; verbose=false)
     q_points_cryst = zeros(Float64, size(q_tot)...)
     cryst_cart_conv!(q_points_cryst, q_tot, unit_cell, reciprocal_lattice, false; q_space=true)
 
-    symmetry_group_q = SymmetriesQSpace(symmetry_group_uc, q_points_cryst)
+    symmetry_group_q = SymmetriesQSpace(symmetry_group_uc, q_points_cryst, unit_cell_structure)
     n_sym = length(symmetry_group_q)
 
     n_dims = 3

--- a/test/test_symmetrize_cartesian_qspace.jl
+++ b/test/test_symmetrize_cartesian_qspace.jl
@@ -17,6 +17,7 @@ function test_symmetrize_cartesian_qspace(; verbose=false)
     R_lat = [0.0 2.7869170943386137 2.7869170943386137 5.573834188677228 5.573834188677226 8.36075128301584 8.36075128301584 11.147668377354455; 0.0 1.6090273346255681 4.827082003876703 6.436109338502272 0.0 1.6090273346255681 4.827082003876703 6.436109338502272; 0.0 4.55101655771302 0.0 4.55101655771302 0.0 4.55101655771302 0.0 4.55101655771302]
 
     unit_cell_structure = zeros(Float64, 3, 1)
+    tau_cart = zeros(Float64, 3, 1)  # atomic positions in cartesian coords (same units as R_lat)
     unit_cell = [2.94954603 1.4747730150000002 1.4747730150000002; 0.0 2.554381791611538 0.8514605972038461; 0.0 0.0 2.408294248783948]
     unit_cell .*= 1.889725989
 
@@ -41,12 +42,12 @@ function test_symmetrize_cartesian_qspace(; verbose=false)
     get_reciprocal_lattice!(reciprocal_lattice, unit_cell)
     cryst_cart_conv!(q_points_cryst, q_tot, unit_cell, reciprocal_lattice, false; q_space = true)
 
-    symmetry_group_q = SymmetriesQSpace(symmetry_group_uc, q_points_cryst)
+    symmetry_group_q = SymmetriesQSpace(symmetry_group_uc, q_points_cryst, unit_cell_structure)
 
     # Convert the matrix in q space
     nq = size(q_tot, 2)
     q_matrix = zeros(Complex{Float64}, 3, 3, nq)
-    matrix_r2q!(q_matrix, rs_matrix, q_tot, itau, R_lat)
+    matrix_r2q!(q_matrix, rs_matrix, q_tot, itau, R_lat, tau_cart)
 
     # Convert everything in crystal coordinates
     q_crystal_mat = similar(q_matrix)
@@ -88,13 +89,13 @@ function test_symmetrize_cartesian_qspace(; verbose=false)
         irt = symmetry_group_q.symmetries.irt[i]
         q_irt = symmetry_group_q.irt_q[i]
         my_irt = symmetry_group_sc.irt[i]
-        uc_trans = symmetry_group_q.symmetries.unit_cell_translations[i]
+        positions = symmetry_group_q.positions
         q_pts = symmetry_group_q.q_points
 
         # My IRT
 
         # Apply the symmetry
-        AtomicSymmetries.apply_symmetry_matrixq!(q_tmp_mat, q_matrix, symmat, irt, q_irt, uc_trans, q_pts)
+        AtomicSymmetries.apply_symmetry_matrixq!(q_tmp_mat, q_matrix, symmat, irt, q_irt, positions, q_pts)
 
         # Apply the symmetry in real space
         AtomicSymmetries.apply_sym_fc!(rs_tmp_mat, rs_matrix, symmat, 3, my_irt)
@@ -104,7 +105,7 @@ function test_symmetrize_cartesian_qspace(; verbose=false)
 
 
         # Convert to q space
-        matrix_r2q!(q_target, rs_tmp_mat, q_tot, itau, R_lat)
+        matrix_r2q!(q_target, rs_tmp_mat, q_tot, itau, R_lat, tau_cart)
 
         @test isapprox(q_target, q_tmp_mat; rtol = 1e-8, atol = 1e-12)
     end
@@ -125,7 +126,7 @@ function test_symmetrize_cartesian_qspace(; verbose=false)
     # Perform the symmetrization in real space
     symmetrize_fc!(rs_matrix, supercell, symmetry_group_sc)
 
-    matrix_r2q!(q_target, rs_matrix, q_tot, itau, R_lat)
+    matrix_r2q!(q_target, rs_matrix, q_tot, itau, R_lat, tau_cart)
     if verbose
         @show q_target
     end

--- a/test/test_symmetrize_qspace.jl
+++ b/test/test_symmetrize_qspace.jl
@@ -120,11 +120,11 @@ function test_symmetrize_q_space(; verbose=false)
     AtomicSymmetries.apply_sym_centroid!(u_next, u_coordinates[1, :], uc_group.symmetries[i_sym], ndims, irt)
 
     # Apply the symmetry in q-space
-    AtomicSymmetries.vector_r2q!(q_coordinates, u_coordinates, q_vec, super_itau, R_lat)
+    AtomicSymmetries.vector_r2q!(q_coordinates, u_coordinates, q_vec, super_itau, R_lat, positions)
 
     #@views AtomicSymmetries.apply_symmetry_vectorq!(q_next[1, :, :], q_coordinates[1, :, :], uc_group.symmetries[2], uc_group.irt[2], irt_q)
 
-    AtomicSymmetries.vector_q2r!(u_next_back, q_coordinates, q_vec, super_itau, R_lat)
+    AtomicSymmetries.vector_q2r!(u_next_back, q_coordinates, q_vec, super_itau, R_lat, positions)
     
     # Test the fourier transform
     if verbose
@@ -140,9 +140,11 @@ function test_symmetrize_q_space(; verbose=false)
     end
     
     AtomicSymmetries.get_irt_q!(irt_q, q_vec, uc_group.symmetries[i_sym])
-    @views AtomicSymmetries.apply_symmetry_vectorq!(q_next[1, :, :], q_coordinates[1, :, :], uc_group.symmetries[i_sym], uc_group.irt[i_sym], irt_q)
+    @views AtomicSymmetries.apply_symmetry_vectorq!(q_next[1, :, :], q_coordinates[1, :, :], uc_group.symmetries[i_sym], uc_group.irt[i_sym], irt_q;
+                                                    positions=positions, q_points=q_vec,
+                                                    translation=uc_group.translations[i_sym])
 
-    AtomicSymmetries.vector_q2r!(u_next_back, q_next, q_vec, super_itau, R_lat)
+    AtomicSymmetries.vector_q2r!(u_next_back, q_next, q_vec, super_itau, R_lat, positions)
  
 
     # Compare the two vectors
@@ -207,10 +209,10 @@ function test_symmetrize_q_space(; verbose=false)
         
         # Perform the fourier transform of the dynamical matrix
         AtomicSymmetries.matrix_r2q!(dynq_trial, fc_trial, q_vec, super_itau,
-                                     R_lat)
-        AtomicSymmetries.matrix_q2r!(fc_backward1, dynq_trial, q_vec, super_itau, R_lat; translations=translations)
+                                     R_lat, positions)
+        AtomicSymmetries.matrix_q2r!(fc_backward1, dynq_trial, q_vec, super_itau, R_lat, positions; translations=translations)
         AtomicSymmetries.matrix_r2q!(dynq_back2, fc_backward1, q_vec, super_itau,
-                                     R_lat)
+                                     R_lat, positions)
 
         # Test the fourier transform of the dynamical matrix
         for iq in 1:n_sc
@@ -237,17 +239,17 @@ function test_symmetrize_q_space(; verbose=false)
                                                uc_group.symmetries[i_sym],
                                                uc_group.irt[i_sym],
                                                irt_q,
-                                               trans_vect,
+                                               positions,
                                                q_vec
                                               )
-        AtomicSymmetries.matrix_q2r!(fc_trial, dynq_back2, q_vec, super_itau, R_lat; translations=translations)
+        AtomicSymmetries.matrix_q2r!(fc_trial, dynq_back2, q_vec, super_itau, R_lat, positions; translations=translations)
         # Now, fc_trial contains the dynamical matrix with the symmetry applied in q space
         # Let us apply the symmetry also to fc_backward1 -> fc_backward2
         AtomicSymmetries.apply_sym_fc!(fc_backward2, fc_backward1, uc_group.symmetries[i_sym], ndims, irt)
 
         dynq_fc_symmetrized = similar(dynq_back2)
         dynq_fc_symmetrized .= 0
-        AtomicSymmetries.matrix_r2q!(dynq_fc_symmetrized, fc_backward2, q_vec, super_itau, R_lat)
+        AtomicSymmetries.matrix_r2q!(dynq_fc_symmetrized, fc_backward2, q_vec, super_itau, R_lat, positions)
 
         # Now we can compare fc_backward2 and fc_backward
         if verbose && print_next
@@ -330,12 +332,12 @@ function test_symmetrize_q_space(; verbose=false)
     # Now, we can test the full symmetrization
     # TODO: THe errpr see,s tp be that fc_backward1 has a lot of zeros and 
     # it is not the real starting point!!!
-    q_symmetries = AtomicSymmetries.SymmetriesQSpace(uc_group, q_vec)
+    q_symmetries = AtomicSymmetries.SymmetriesQSpace(uc_group, q_vec, positions)
     AtomicSymmetries.symmetrize_matrix_q!(dynq_back2, dynq_trial, q_symmetries)
-    AtomicSymmetries.matrix_q2r!(fc_trial, dynq_back2, q_vec, super_itau, R_lat; translations=translations)
+    AtomicSymmetries.matrix_q2r!(fc_trial, dynq_back2, q_vec, super_itau, R_lat, positions; translations=translations)
 
     # Now let us perform the symmetrization directly in cartesian space
-    AtomicSymmetries.matrix_q2r!(fc_backward2, dynq_trial, q_vec, super_itau, R_lat; translations=translations)
+    AtomicSymmetries.matrix_q2r!(fc_backward2, dynq_trial, q_vec, super_itau, R_lat, positions; translations=translations)
     fc_backward1 = copy(fc_backward2)
     sc_group.symmetrize_fc!(fc_backward2)
 
@@ -399,6 +401,7 @@ function test_fourier_matrix(; verbose=false)
     q_tot = [0.0 0.5; 0.0 0.0; 0.0 0.0]
     R_lat = [0.0 0.0 1.0 1.0; 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0]
     itau = [1, 2, 1, 2]
+    tau = [0.0 0.3; 0.0 0.1; 0.0 0.2]
     translations = [[1, 2, 3, 4], [3, 4, 1, 2]]
 
     
@@ -411,13 +414,13 @@ function test_fourier_matrix(; verbose=false)
     phi_q_bis = similar(phi_q)
 
     # Convert in q space
-    matrix_r2q!(phi_q, phi_r, q_tot, itau, R_lat)
+    matrix_r2q!(phi_q, phi_r, q_tot, itau, R_lat, tau)
 
     # Convert back in r space
-    matrix_q2r!(phi_q2r, phi_q, q_tot, itau, R_lat;
+    matrix_q2r!(phi_q2r, phi_q, q_tot, itau, R_lat, tau;
                 translations)
 
-    matrix_r2q!(phi_q_bis, phi_q2r, q_tot, itau, R_lat)
+    matrix_r2q!(phi_q_bis, phi_q2r, q_tot, itau, R_lat, tau)
 
     for iq in 1:2
         for k in 1:6


### PR DESCRIPTION
The Fourier transform (vector_r2q!/q2r!, matrix_r2q!/q2r!) now uses the phase factor computed from the equilibrium atomic positions R + τ_a instead of the cell origin R only. This gauge makes q-space quantities smooth in q, which is much better suited for interpolation, at the price of losing periodicity in the Brillouin zone.

Consequences implemented throughout the code:
- All FT functions take a new required argument tau (primitive-cell atomic positions, same coordinates as R_lat).
- SymmetriesQSpace stores the atomic positions (crystal coordinates), required by the constructor.
- apply_symmetry_matrixq!: the fractional-translation phase factors cancel in this gauge; they are replaced by the BZ-folding phases e^{2πi G·(τ_s(a) - τ_s(b))} with G = S^{-T}q - q_grid.
- apply_symmetry_vectorq!: optionally applies the folding phase and the fractional-translation phase e^{-2πi (S^{-T}q)·v} (used by rotate_vector!).
- impose_hermitianity_q!: time reversal through -q+G folding now includes the block phases; new methods taking positions/q_points or SymmetriesQSpace.
- Fixed a pre-existing bug in vector_q2r!: with absolute_positions=true the equilibrium positions were wrongly scaled by 1/sqrt(nq).
- Documentation (docs/src/fourier_symmetries.md and docstrings) rewritten for the new gauge; version bumped to 0.12.0 (breaking).
- New test suite test/test_fourier_gauge.jl (CsCl structure with tau=(½,½,½), full Oh group, 222 nontrivial G foldings) validating the gauge relation, roundtrips, real- vs q-space symmetry application (matrix and vector), hermitianity imposition, and negative controls; existing q-space tests updated (the LaAlO3 non-symmorphic test acts as oracle).